### PR TITLE
cli: add basic configuration commands

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -1,0 +1,86 @@
+/*
+This file is part of REANA.
+Copyright (C) 2022 CERN.
+
+REANA is free software; you can redistribute it and/or modify it
+under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"reanahub/reana-client-go/utils"
+	"reanahub/reana-client-go/validation"
+
+	"github.com/spf13/cobra"
+)
+
+type Info struct {
+	ComputeBackends struct {
+		Title string   `json:"title"`
+		Value []string `json:"value"`
+	} `json:"compute_backends"`
+	DefaultWorkspace struct {
+		Title string `json:"title"`
+		Value string `json:"value"`
+	} `json:"default_workspace"`
+	AvailableWorkspaces struct {
+		Title string   `json:"title"`
+		Value []string `json:"value"`
+	} `json:"workspaces_available"`
+}
+
+var infoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "List cluster general information.",
+	Long: `
+List cluster general information.
+
+The ` + "``info``" + ` command lists general information about the cluster.
+
+Lists all the available workspaces. It also returns the default workspace
+defined by the admin.
+
+Examples:
+
+  $ reana-client info
+	`,
+	Run: func(cmd *cobra.Command, args []string) {
+		jsonOutput, _ := cmd.Flags().GetBool("json")
+		token, _ := cmd.Flags().GetString("access-token")
+		serverURL := os.Getenv("REANA_SERVER_URL")
+		validation.ValidateAccessToken(token)
+		validation.ValidateServerURL(serverURL)
+		info(token, serverURL, jsonOutput)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(infoCmd)
+
+	infoCmd.Flags().BoolP("json", "", false, "Get output in JSON format.")
+	infoCmd.Flags().StringP("access-token", "t", os.Getenv("REANA_ACCESS_TOKEN"), "Access token of the current user.")
+}
+
+func info(token string, serverURL string, jsonOutput bool) {
+	respBytes := utils.NewRequest(token, serverURL, "/api/info")
+	i := Info{}
+
+	if err := json.Unmarshal(respBytes, &i); err != nil {
+		fmt.Printf("Could not unmarshal reponseBytes. %v", err)
+	}
+	if jsonOutput {
+		utils.DisplayJsonOutput(i)
+	} else {
+		response := fmt.Sprintf("List of supported compute backends: %s \n", strings.Join(i.ComputeBackends.Value, ", ")) +
+			fmt.Sprintf("Default workspace: %s \n", i.DefaultWorkspace.Value) +
+			fmt.Sprintf("List of available workspaces: %s \n", strings.Join(i.AvailableWorkspaces.Value, ", "))
+
+		fmt.Print(response)
+	}
+}

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -1,0 +1,70 @@
+/*
+This file is part of REANA.
+Copyright (C) 2022 CERN.
+
+REANA is free software; you can redistribute it and/or modify it
+under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"reanahub/reana-client-go/utils"
+	"reanahub/reana-client-go/validation"
+
+	"github.com/spf13/cobra"
+)
+
+type Ping struct {
+	Email         string `json:"email"`
+	FullName      string `json:"full_name"`
+	Username      string `json:"username"`
+	ServerVersion string `json:"reana_server_version"`
+}
+
+var pingCmd = &cobra.Command{
+	Use:   "ping",
+	Short: "Check connection to REANA server.",
+	Long: `
+Check connection to REANA server.
+
+The ` + "``ping``" + ` command allows to test connection to REANA server.
+
+Examples:
+
+  $ reana-client ping
+	`,
+	Run: func(cmd *cobra.Command, args []string) {
+		token, _ := cmd.Flags().GetString("access-token")
+		serverURL := os.Getenv("REANA_SERVER_URL")
+		validation.ValidateAccessToken(token)
+		validation.ValidateServerURL(serverURL)
+		ping(token, serverURL)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(pingCmd)
+
+	pingCmd.Flags().StringP("access-token", "t", os.Getenv("REANA_ACCESS_TOKEN"), "Access token of the current user.")
+}
+
+func ping(token string, serverURL string) {
+	respBytes := utils.NewRequest(token, serverURL, "/api/you")
+	p := Ping{}
+
+	if err := json.Unmarshal(respBytes, &p); err != nil {
+		fmt.Printf("Could not unmarshal reponseBytes. %v", err)
+	}
+	response := fmt.Sprintf("REANA server: %s \n", serverURL) +
+		fmt.Sprintf("REANA server version: %s \n", p.ServerVersion) +
+		fmt.Sprintf("REANA client version: %s \n", version) +
+		fmt.Sprintf("Authenticated as: <%s> \n", p.Email) +
+		fmt.Sprintf("Status: %s ", "Connected")
+
+	fmt.Println(response)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,34 @@
+/*
+This file is part of REANA.
+Copyright (C) 2022 CERN.
+
+REANA is free software; you can redistribute it and/or modify it
+under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "reana-client",
+	Short: "REANA client for interacting with REANA server.",
+	Long:  "REANA client for interacting with REANA server.",
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.PersistentFlags().BoolP("loglevel", "l", false, "Sets log level [DEBUG|INFO|WARNING]")
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,38 @@
+/*
+This file is part of REANA.
+Copyright (C) 2022 CERN.
+
+REANA is free software; you can redistribute it and/or modify it
+under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var version = "v0.0.0-alpha.1"
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show version.",
+	Long: `
+Show version.
+
+The ` + "``version``" + ` command shows REANA client version.
+
+Examples:
+
+  $ reana-client version
+	`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module reanahub/reana-client-go
+
+go 1.18
+
+require github.com/spf13/cobra v1.4.0
+
+require (
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
+github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
+github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,15 @@
+/*
+This file is part of REANA.
+Copyright (C) 2022 CERN.
+
+REANA is free software; you can redistribute it and/or modify it
+under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+package main
+
+import "reanahub/reana-client-go/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,56 @@
+/*
+This file is part of REANA.
+Copyright (C) 2022 CERN.
+
+REANA is free software; you can redistribute it and/or modify it
+under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+package utils
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+)
+
+func DisplayJsonOutput(output any) {
+	byteArray, err := json.MarshalIndent(output, "", "  ")
+
+	if err != nil {
+		fmt.Println("Error: ", err)
+	}
+
+	fmt.Println(string(byteArray))
+}
+
+func NewRequest(token string, serverURL string, endpoint string) []byte {
+	// disable certificate security checks
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
+	url := serverURL + endpoint + "?access_token=" + token
+	request, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		fmt.Println("Error:", err)
+		os.Exit(1)
+	}
+
+	resp, err := http.DefaultClient.Do(request)
+	if err != nil {
+		fmt.Println("Error:", err)
+		os.Exit(1)
+	}
+
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println("Error:", err)
+		os.Exit(1)
+	}
+
+	return respBytes
+}

--- a/validation/utils.go
+++ b/validation/utils.go
@@ -1,0 +1,29 @@
+/*
+This file is part of REANA.
+Copyright (C) 2022 CERN.
+
+REANA is free software; you can redistribute it and/or modify it
+under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+package validation
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func ValidateAccessToken(token string) {
+	if strings.TrimSpace(token) == "" {
+		fmt.Println("Error: Please provide your access token by using the -t/--access-token flag, or by setting the REANA_ACCESS_TOKEN environment variable.")
+		os.Exit(1)
+	}
+}
+
+func ValidateServerURL(serverURL string) {
+	if strings.TrimSpace(serverURL) == "" {
+		fmt.Println("Error: Please set REANA_SERVER_URL environment variable.")
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Added basic configuration commands: `version`, `ping`, `info`

To test:
- `go run .`
- `go run . ping`
- `go run . info --json`
