### PR TITLE
cli: introduce unit tests for the `version` command

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -21,36 +21,36 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var infoCmd = &cobra.Command{
-	Use:   "info",
-	Short: "List cluster general information.",
-	Long: `
-List cluster general information.
+func newInfoCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "info",
+		Short: "List cluster general information.",
+		Long: `
+	List cluster general information.
 
-The ` + "``info``" + ` command lists general information about the cluster.
+	The ` + "``info``" + ` command lists general information about the cluster.
 
-Lists all the available workspaces. It also returns the default workspace
-defined by the admin.
+	Lists all the available workspaces. It also returns the default workspace
+	defined by the admin.
 
-Examples:
+	Examples:
 
-  $ reana-client info
-	`,
-	Run: func(cmd *cobra.Command, args []string) {
-		jsonOutput, _ := cmd.Flags().GetBool("json")
-		token, _ := cmd.Flags().GetString("access-token")
-		serverURL := os.Getenv("REANA_SERVER_URL")
-		validation.ValidateAccessToken(token)
-		validation.ValidateServerURL(serverURL)
-		info(token, jsonOutput)
-	},
-}
+	  $ reana-client info
+		`,
+		Run: func(cmd *cobra.Command, args []string) {
+			jsonOutput, _ := cmd.Flags().GetBool("json")
+			token, _ := cmd.Flags().GetString("access-token")
+			serverURL := os.Getenv("REANA_SERVER_URL")
+			validation.ValidateAccessToken(token)
+			validation.ValidateServerURL(serverURL)
+			info(token, jsonOutput)
+		},
+	}
 
-func init() {
-	rootCmd.AddCommand(infoCmd)
+	cmd.Flags().BoolP("json", "", false, "Get output in JSON format.")
+	cmd.Flags().StringP("access-token", "t", os.Getenv("REANA_ACCESS_TOKEN"), "Access token of the current user.")
 
-	infoCmd.Flags().BoolP("json", "", false, "Get output in JSON format.")
-	infoCmd.Flags().StringP("access-token", "t", os.Getenv("REANA_ACCESS_TOKEN"), "Access token of the current user.")
+	return cmd
 }
 
 func info(token string, jsonOutput bool) {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -37,43 +37,43 @@ filters are 'name' and 'status'.
 // Available run statuses
 var runStatuses = []string{"created", "running", "finished", "failed", "deleted", "stopped", "queued", "pending"}
 
-var listCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List all workflows and sessions.",
-	Long: `List all workflows and sessions.
+func newListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all workflows and sessions.",
+		Long: `List all workflows and sessions.
 
-The ` + "``list``" + ` command lists workflows and sessions. By default, the list of
-workflows is returned. If you would like to see the list of your open
-interactive sessions, you need to pass the ` + "``--sessions``" + ` command-line
-option.
+	The ` + "``list``" + ` command lists workflows and sessions. By default, the list of
+	workflows is returned. If you would like to see the list of your open
+	interactive sessions, you need to pass the ` + "``--sessions``" + ` command-line
+	option.
 
-Example:
+	Example:
 
-  $ reana-client list --all
+	  $ reana-client list --all
 
-  $ reana-client list --sessions
+	  $ reana-client list --sessions
 
-  $ reana-client list --verbose --bytes
+	  $ reana-client list --verbose --bytes
 
-  `,
-	Run: func(cmd *cobra.Command, args []string) {
-		token, _ := cmd.Flags().GetString("access-token")
-		serverURL := os.Getenv("REANA_SERVER_URL")
-		validation.ValidateAccessToken(token)
-		validation.ValidateServerURL(serverURL)
-		list(cmd)
-	},
-}
+	  `,
+		Run: func(cmd *cobra.Command, args []string) {
+			token, _ := cmd.Flags().GetString("access-token")
+			serverURL := os.Getenv("REANA_SERVER_URL")
+			validation.ValidateAccessToken(token)
+			validation.ValidateServerURL(serverURL)
+			list(cmd)
+		},
+	}
 
-func init() {
-	rootCmd.AddCommand(listCmd)
+	cmd.Flags().StringP("access-token", "t", os.Getenv("REANA_ACCESS_TOKEN"), "Access token of the current user.")
+	cmd.Flags().StringP("workflow", "w", "", "List all runs of the given workflow.")
+	cmd.Flags().StringP("sessions", "s", "", "List all open interactive sessions.")
+	cmd.Flags().String("format", "", listFormatFlagDescription)
+	cmd.Flags().BoolP("json", "", false, "Get output in JSON format.")
+	cmd.Flags().StringArray("filter", []string{}, listFilterFlagDescription)
 
-	listCmd.Flags().StringP("access-token", "t", os.Getenv("REANA_ACCESS_TOKEN"), "Access token of the current user.")
-	listCmd.Flags().StringP("workflow", "w", "", "List all runs of the given workflow.")
-	listCmd.Flags().StringP("sessions", "s", "", "List all open interactive sessions.")
-	listCmd.Flags().String("format", "", listFormatFlagDescription)
-	listCmd.Flags().BoolP("json", "", false, "Get output in JSON format.")
-	listCmd.Flags().StringArray("filter", []string{}, listFilterFlagDescription)
+	return cmd
 }
 
 func list(cmd *cobra.Command) {

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -19,31 +19,31 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var pingCmd = &cobra.Command{
-	Use:   "ping",
-	Short: "Check connection to REANA server.",
-	Long: `
-Check connection to REANA server.
+func newPingCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ping",
+		Short: "Check connection to REANA server.",
+		Long: `
+	Check connection to REANA server.
 
-The ` + "``ping``" + ` command allows to test connection to REANA server.
+	The ` + "``ping``" + ` command allows to test connection to REANA server.
 
-Examples:
+	Examples:
 
-  $ reana-client ping
-	`,
-	Run: func(cmd *cobra.Command, args []string) {
-		token, _ := cmd.Flags().GetString("access-token")
-		serverURL := os.Getenv("REANA_SERVER_URL")
-		validation.ValidateAccessToken(token)
-		validation.ValidateServerURL(serverURL)
-		ping(token, serverURL)
-	},
-}
+	  $ reana-client ping
+		`,
+		Run: func(cmd *cobra.Command, args []string) {
+			token, _ := cmd.Flags().GetString("access-token")
+			serverURL := os.Getenv("REANA_SERVER_URL")
+			validation.ValidateAccessToken(token)
+			validation.ValidateServerURL(serverURL)
+			ping(token, serverURL)
+		},
+	}
 
-func init() {
-	rootCmd.AddCommand(pingCmd)
+	cmd.Flags().StringP("access-token", "t", os.Getenv("REANA_ACCESS_TOKEN"), "Access token of the current user.")
 
-	pingCmd.Flags().StringP("access-token", "t", os.Getenv("REANA_ACCESS_TOKEN"), "Access token of the current user.")
+	return cmd
 }
 
 func ping(token string, serverURL string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,26 +9,23 @@ under the terms of the MIT License; see LICENSE file for more details.
 package cmd
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 )
 
-var rootCmd = &cobra.Command{
-	Use:   "reana-client",
-	Short: "REANA client for interacting with REANA server.",
-	Long:  "REANA client for interacting with REANA server.",
-}
-
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reana-client",
+		Short: "REANA client for interacting with REANA server.",
+		Long:  "REANA client for interacting with REANA server.",
 	}
-}
 
-func init() {
-	rootCmd.PersistentFlags().BoolP("loglevel", "l", false, "Sets log level [DEBUG|INFO|WARNING]")
+	cmd.PersistentFlags().BoolP("loglevel", "l", false, "Sets log level [DEBUG|INFO|WARNING]")
+
+	// Add commands
+	cmd.AddCommand(newVersionCmd())
+	cmd.AddCommand(newPingCmd())
+	cmd.AddCommand(newInfoCmd())
+	cmd.AddCommand(newListCmd())
+
+	return cmd
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,30 +9,28 @@ under the terms of the MIT License; see LICENSE file for more details.
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
 var version = "v0.0.0-alpha.1"
 
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Show version.",
-	Long: `
-Show version.
+func newVersionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Show version.",
+		Long: `
+	Show version.
 
-The ` + "``version``" + ` command shows REANA client version.
+	The ` + "``version``" + ` command shows REANA client version.
 
-Examples:
+	Examples:
 
-  $ reana-client version
-	`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(version)
-	},
-}
+	  $ reana-client version
+		`,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Println(version)
+		},
+	}
 
-func init() {
-	rootCmd.AddCommand(versionCmd)
+	return cmd
 }

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,24 @@
+/*
+This file is part of REANA.
+Copyright (C) 2022 CERN.
+
+REANA is free software; you can redistribute it and/or modify it
+under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+package cmd
+
+import (
+	"reanahub/reana-client-go/utils"
+	"strings"
+	"testing"
+)
+
+func TestVersionCmd(t *testing.T) {
+	cmd := NewRootCmd()
+	out, _ := utils.ExecuteCommand(cmd, "version")
+
+	if strings.TrimSpace(out) != version {
+		t.Fatalf("Expected: \"%s\", got: \"%s\"", version, out)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -8,8 +8,16 @@ under the terms of the MIT License; see LICENSE file for more details.
 
 package main
 
-import "reanahub/reana-client-go/cmd"
+import (
+	"os"
+	"reanahub/reana-client-go/cmd"
+)
 
 func main() {
-	cmd.Execute()
+	rootCmd := cmd.NewRootCmd()
+	err := rootCmd.Execute()
+
+	if err != nil {
+		os.Exit(1)
+	}
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -9,13 +9,27 @@ under the terms of the MIT License; see LICENSE file for more details.
 package utils
 
 import (
+	"bytes"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
+
+	"github.com/spf13/cobra"
 )
+
+func ExecuteCommand(root *cobra.Command, args ...string) (output string, err error) {
+	buf := new(bytes.Buffer)
+	root.SetOut(buf)
+	root.SetErr(buf)
+	root.SetArgs(args)
+
+	err = root.Execute()
+
+	return buf.String(), err
+}
 
 func DisplayJsonOutput(output any) {
 	byteArray, err := json.MarshalIndent(output, "", "  ")


### PR DESCRIPTION
- Updates commands by wrapping initialization inside a function (same technique used in `helm`, `kind`, `hugo`, etc..) to make it easier to test it
- Introduce some basic unit test for the `version` command as an example how to test cobra CLI commands

To test:
```
go test -v ./...
```