### PR TITLE
cli: Hide access token from the command description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+reana-client-go
 
 # Test binary, built with `go test -c`
 *.test
@@ -13,3 +14,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# IDE Files
+.idea/

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -5,3 +5,4 @@ The list of contributors in alphabetical order:
 
 - `Audrius Mecionis <https://orcid.org/0000-0002-3759-1663>`_
 - `Tibor Simko <https://orcid.org/0000-0001-7202-5803>`_
+- `Bruno Rosendo <https://orcid.org/0000-0002-0923-3148>`_

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -40,6 +40,9 @@ func newInfoCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			jsonOutput, _ := cmd.Flags().GetBool("json")
 			token, _ := cmd.Flags().GetString("access-token")
+			if token == "" {
+				token = os.Getenv("REANA_ACCESS_TOKEN")
+			}
 			serverURL := os.Getenv("REANA_SERVER_URL")
 			validation.ValidateAccessToken(token)
 			validation.ValidateServerURL(serverURL)
@@ -48,7 +51,7 @@ func newInfoCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolP("json", "", false, "Get output in JSON format.")
-	cmd.Flags().StringP("access-token", "t", os.Getenv("REANA_ACCESS_TOKEN"), "Access token of the current user.")
+	cmd.Flags().StringP("access-token", "t", "", "Access token of the current user.")
 
 	return cmd
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -59,6 +59,9 @@ func newListCmd() *cobra.Command {
 	  `,
 		Run: func(cmd *cobra.Command, args []string) {
 			token, _ := cmd.Flags().GetString("access-token")
+			if token == "" {
+				token = os.Getenv("REANA_ACCESS_TOKEN")
+			}
 			serverURL := os.Getenv("REANA_SERVER_URL")
 			validation.ValidateAccessToken(token)
 			validation.ValidateServerURL(serverURL)
@@ -66,7 +69,7 @@ func newListCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringP("access-token", "t", os.Getenv("REANA_ACCESS_TOKEN"), "Access token of the current user.")
+	cmd.Flags().StringP("access-token", "t", "", "Access token of the current user.")
 	cmd.Flags().StringP("workflow", "w", "", "List all runs of the given workflow.")
 	cmd.Flags().StringP("sessions", "s", "", "List all open interactive sessions.")
 	cmd.Flags().String("format", "", listFormatFlagDescription)
@@ -78,6 +81,9 @@ func newListCmd() *cobra.Command {
 
 func list(cmd *cobra.Command) {
 	token, _ := cmd.Flags().GetString("access-token")
+	if token == "" {
+		token = os.Getenv("REANA_ACCESS_TOKEN")
+	}
 	workflow, _ := cmd.Flags().GetString("workflow")
 	jsonOutput, _ := cmd.Flags().GetBool("json")
 	filter, _ := cmd.Flags().GetStringArray("filter")

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -34,6 +34,9 @@ func newPingCmd() *cobra.Command {
 		`,
 		Run: func(cmd *cobra.Command, args []string) {
 			token, _ := cmd.Flags().GetString("access-token")
+			if token == "" {
+				token = os.Getenv("REANA_ACCESS_TOKEN")
+			}
 			serverURL := os.Getenv("REANA_SERVER_URL")
 			validation.ValidateAccessToken(token)
 			validation.ValidateServerURL(serverURL)
@@ -41,7 +44,7 @@ func newPingCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringP("access-token", "t", os.Getenv("REANA_ACCESS_TOKEN"), "Access token of the current user.")
+	cmd.Flags().StringP("access-token", "t", "", "Access token of the current user.")
 
 	return cmd
 }


### PR DESCRIPTION
closes #11

Hides the access token from the command description when using `--help`. Did it by having our own logic for a default value, instead of using Cobra's feature