### PR TITLE
setup: add a Makefile for some custom build tasks

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -15,6 +15,6 @@ the tests to ensure that everything is operating correctly:
 
 .. code-block:: console
 
-    $ ./run-tests.sh
+    $ make test
 
 Each pull request should preserve or increase code coverage.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# This file is part of REANA.
+# Copyright (C) 2022 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+SWAGGER := docker run --rm -it -e GOPATH=$(shell go env GOPATH):/go -v $(HOME):$(HOME) -w $(shell pwd) quay.io/goswagger/swagger
+
+build:
+	go build
+
+release:
+	version=$(shell go run . version) && \
+	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o reana-client-go-$$version-darwin-amd64 && \
+	GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o reana-client-go-$$version-darwin-arm64 && \
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o reana-client-go-$$version-linux-amd64 && \
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o reana-client-go-$$version-linux-arm64
+
+test:
+	go test -v ./...
+
+validate-spec:
+	$(SWAGGER) validate "../reana-server/docs/openapi.json"
+
+generate-api-client:
+	$(SWAGGER) generate client -f "../reana-server/docs/openapi.json" -A api

--- a/client/operations/create_gitlab_webhook_parameters.go
+++ b/client/operations/create_gitlab_webhook_parameters.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
-	"github.com/go-openapi/swag"
 )
 
 // NewCreateGitlabWebhookParams creates a new CreateGitlabWebhookParams object,
@@ -60,11 +59,11 @@ func NewCreateGitlabWebhookParamsWithHTTPClient(client *http.Client) *CreateGitl
 */
 type CreateGitlabWebhookParams struct {
 
-	/* ProjectID.
+	/* Data.
 
-	   The GitLab project id.
+	   Data required to set a new webhook from GitLab.
 	*/
-	ProjectID int64
+	Data CreateGitlabWebhookBody
 
 	timeout    time.Duration
 	Context    context.Context
@@ -119,15 +118,15 @@ func (o *CreateGitlabWebhookParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithProjectID adds the projectID to the create gitlab webhook params
-func (o *CreateGitlabWebhookParams) WithProjectID(projectID int64) *CreateGitlabWebhookParams {
-	o.SetProjectID(projectID)
+// WithData adds the data to the create gitlab webhook params
+func (o *CreateGitlabWebhookParams) WithData(data CreateGitlabWebhookBody) *CreateGitlabWebhookParams {
+	o.SetData(data)
 	return o
 }
 
-// SetProjectID adds the projectId to the create gitlab webhook params
-func (o *CreateGitlabWebhookParams) SetProjectID(projectID int64) {
-	o.ProjectID = projectID
+// SetData adds the data to the create gitlab webhook params
+func (o *CreateGitlabWebhookParams) SetData(data CreateGitlabWebhookBody) {
+	o.Data = data
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -137,15 +136,8 @@ func (o *CreateGitlabWebhookParams) WriteToRequest(r runtime.ClientRequest, reg 
 		return err
 	}
 	var res []error
-
-	// query param project_id
-	qrProjectID := o.ProjectID
-	qProjectID := swag.FormatInt64(qrProjectID)
-	if qProjectID != "" {
-
-		if err := r.SetQueryParam("project_id", qProjectID); err != nil {
-			return err
-		}
+	if err := r.SetBodyParam(o.Data); err != nil {
+		return err
 	}
 
 	if len(res) > 0 {

--- a/client/operations/create_gitlab_webhook_responses.go
+++ b/client/operations/create_gitlab_webhook_responses.go
@@ -6,10 +6,14 @@ package operations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // CreateGitlabWebhookReader is a Reader for the CreateGitlabWebhook structure.
@@ -103,5 +107,61 @@ func (o *CreateGitlabWebhookInternalServerError) Error() string {
 
 func (o *CreateGitlabWebhookInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	return nil
+}
+
+/*CreateGitlabWebhookBody create gitlab webhook body
+swagger:model CreateGitlabWebhookBody
+*/
+type CreateGitlabWebhookBody struct {
+
+	// The GitLab project id.
+	// Required: true
+	ProjectID *string `json:"project_id"`
+}
+
+// Validate validates this create gitlab webhook body
+func (o *CreateGitlabWebhookBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateProjectID(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *CreateGitlabWebhookBody) validateProjectID(formats strfmt.Registry) error {
+
+	if err := validate.Required("data"+"."+"project_id", "body", o.ProjectID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this create gitlab webhook body based on context it is used
+func (o *CreateGitlabWebhookBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *CreateGitlabWebhookBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *CreateGitlabWebhookBody) UnmarshalBinary(b []byte) error {
+	var res CreateGitlabWebhookBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
 	return nil
 }

--- a/client/operations/delete_gitlab_webhook_parameters.go
+++ b/client/operations/delete_gitlab_webhook_parameters.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
-	"github.com/go-openapi/swag"
 )
 
 // NewDeleteGitlabWebhookParams creates a new DeleteGitlabWebhookParams object,
@@ -60,17 +59,11 @@ func NewDeleteGitlabWebhookParamsWithHTTPClient(client *http.Client) *DeleteGitl
 */
 type DeleteGitlabWebhookParams struct {
 
-	/* HookID.
+	/* Data.
 
-	   The GitLab webhook id of the project.
+	   Data required to delete an existing webhook from GitLab.
 	*/
-	HookID int64
-
-	/* ProjectID.
-
-	   The GitLab project id.
-	*/
-	ProjectID int64
+	Data DeleteGitlabWebhookBody
 
 	timeout    time.Duration
 	Context    context.Context
@@ -125,26 +118,15 @@ func (o *DeleteGitlabWebhookParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
-// WithHookID adds the hookID to the delete gitlab webhook params
-func (o *DeleteGitlabWebhookParams) WithHookID(hookID int64) *DeleteGitlabWebhookParams {
-	o.SetHookID(hookID)
+// WithData adds the data to the delete gitlab webhook params
+func (o *DeleteGitlabWebhookParams) WithData(data DeleteGitlabWebhookBody) *DeleteGitlabWebhookParams {
+	o.SetData(data)
 	return o
 }
 
-// SetHookID adds the hookId to the delete gitlab webhook params
-func (o *DeleteGitlabWebhookParams) SetHookID(hookID int64) {
-	o.HookID = hookID
-}
-
-// WithProjectID adds the projectID to the delete gitlab webhook params
-func (o *DeleteGitlabWebhookParams) WithProjectID(projectID int64) *DeleteGitlabWebhookParams {
-	o.SetProjectID(projectID)
-	return o
-}
-
-// SetProjectID adds the projectId to the delete gitlab webhook params
-func (o *DeleteGitlabWebhookParams) SetProjectID(projectID int64) {
-	o.ProjectID = projectID
+// SetData adds the data to the delete gitlab webhook params
+func (o *DeleteGitlabWebhookParams) SetData(data DeleteGitlabWebhookBody) {
+	o.Data = data
 }
 
 // WriteToRequest writes these params to a swagger request
@@ -154,25 +136,8 @@ func (o *DeleteGitlabWebhookParams) WriteToRequest(r runtime.ClientRequest, reg 
 		return err
 	}
 	var res []error
-
-	// query param hook_id
-	qrHookID := o.HookID
-	qHookID := swag.FormatInt64(qrHookID)
-	if qHookID != "" {
-
-		if err := r.SetQueryParam("hook_id", qHookID); err != nil {
-			return err
-		}
-	}
-
-	// query param project_id
-	qrProjectID := o.ProjectID
-	qProjectID := swag.FormatInt64(qrProjectID)
-	if qProjectID != "" {
-
-		if err := r.SetQueryParam("project_id", qProjectID); err != nil {
-			return err
-		}
+	if err := r.SetBodyParam(o.Data); err != nil {
+		return err
 	}
 
 	if len(res) > 0 {

--- a/client/operations/delete_gitlab_webhook_responses.go
+++ b/client/operations/delete_gitlab_webhook_responses.go
@@ -6,10 +6,14 @@ package operations
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // DeleteGitlabWebhookReader is a Reader for the DeleteGitlabWebhook structure.
@@ -130,5 +134,78 @@ func (o *DeleteGitlabWebhookInternalServerError) Error() string {
 
 func (o *DeleteGitlabWebhookInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	return nil
+}
+
+/*DeleteGitlabWebhookBody delete gitlab webhook body
+swagger:model DeleteGitlabWebhookBody
+*/
+type DeleteGitlabWebhookBody struct {
+
+	// The GitLab webhook id of the project.
+	// Required: true
+	HookID *int64 `json:"hook_id"`
+
+	// The GitLab project id.
+	// Required: true
+	ProjectID *string `json:"project_id"`
+}
+
+// Validate validates this delete gitlab webhook body
+func (o *DeleteGitlabWebhookBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateHookID(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateProjectID(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *DeleteGitlabWebhookBody) validateHookID(formats strfmt.Registry) error {
+
+	if err := validate.Required("data"+"."+"hook_id", "body", o.HookID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *DeleteGitlabWebhookBody) validateProjectID(formats strfmt.Registry) error {
+
+	if err := validate.Required("data"+"."+"project_id", "body", o.ProjectID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validates this delete gitlab webhook body based on context it is used
+func (o *DeleteGitlabWebhookBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *DeleteGitlabWebhookBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *DeleteGitlabWebhookBody) UnmarshalBinary(b []byte) error {
+	var res DeleteGitlabWebhookBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
 	return nil
 }

--- a/client/operations/get_workflows_parameters.go
+++ b/client/operations/get_workflows_parameters.go
@@ -72,6 +72,12 @@ type GetWorkflowsParams struct {
 	*/
 	IncludeProgress *bool
 
+	/* IncludeRetentionRules.
+
+	   Include workspace retention rules of the workflows.
+	*/
+	IncludeRetentionRules *bool
+
 	/* IncludeWorkspaceSize.
 
 	   Include size information of the workspace.
@@ -199,6 +205,17 @@ func (o *GetWorkflowsParams) WithIncludeProgress(includeProgress *bool) *GetWork
 // SetIncludeProgress adds the includeProgress to the get workflows params
 func (o *GetWorkflowsParams) SetIncludeProgress(includeProgress *bool) {
 	o.IncludeProgress = includeProgress
+}
+
+// WithIncludeRetentionRules adds the includeRetentionRules to the get workflows params
+func (o *GetWorkflowsParams) WithIncludeRetentionRules(includeRetentionRules *bool) *GetWorkflowsParams {
+	o.SetIncludeRetentionRules(includeRetentionRules)
+	return o
+}
+
+// SetIncludeRetentionRules adds the includeRetentionRules to the get workflows params
+func (o *GetWorkflowsParams) SetIncludeRetentionRules(includeRetentionRules *bool) {
+	o.IncludeRetentionRules = includeRetentionRules
 }
 
 // WithIncludeWorkspaceSize adds the includeWorkspaceSize to the get workflows params
@@ -337,6 +354,23 @@ func (o *GetWorkflowsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.
 		if qIncludeProgress != "" {
 
 			if err := r.SetQueryParam("include_progress", qIncludeProgress); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.IncludeRetentionRules != nil {
+
+		// query param include_retention_rules
+		var qrIncludeRetentionRules bool
+
+		if o.IncludeRetentionRules != nil {
+			qrIncludeRetentionRules = *o.IncludeRetentionRules
+		}
+		qIncludeRetentionRules := swag.FormatBool(qrIncludeRetentionRules)
+		if qIncludeRetentionRules != "" {
+
+			if err := r.SetQueryParam("include_retention_rules", qIncludeRetentionRules); err != nil {
 				return err
 			}
 		}

--- a/client/operations/operations_client.go
+++ b/client/operations/operations_client.go
@@ -392,7 +392,7 @@ func (a *Client) DownloadFile(params *DownloadFileParams, writer io.Writer, opts
 		ID:                 "download_file",
 		Method:             "GET",
 		PathPattern:        "/api/workflows/{workflow_id_or_name}/workspace/{file_name}",
-		ProducesMediaTypes: []string{"multipart/form-data"},
+		ProducesMediaTypes: []string{"application/json", "application/octet-stream", "application/zip", "image/*", "text/html"},
 		ConsumesMediaTypes: []string{"application/json"},
 		Schemes:            []string{"http"},
 		Params:             params,

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -21,22 +21,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const infoDesc = `
+List cluster general information.
+
+The ` + "``info``" + ` command lists general information about the cluster.
+
+Lists all the available workspaces. It also returns the default workspace
+defined by the admin.
+`
+
 func newInfoCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "info",
 		Short: "List cluster general information.",
-		Long: `
-	List cluster general information.
-
-	The ` + "``info``" + ` command lists general information about the cluster.
-
-	Lists all the available workspaces. It also returns the default workspace
-	defined by the admin.
-
-	Examples:
-
-	  $ reana-client info
-		`,
+		Long:  infoDesc,
 		Run: func(cmd *cobra.Command, args []string) {
 			jsonOutput, _ := cmd.Flags().GetBool("json")
 			token, _ := cmd.Flags().GetString("access-token")

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -22,16 +22,33 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-var listFormatFlagDescription = `Format output according to column titles or column
+const listFormatFlagDesc = `Format output according to column titles or column
 values. Use <columm_name>=<column_value> format.
 E.g. display workflow with failed status and named test_workflow
 --format status=failed,name=test_workflow.
 `
 
-var listFilterFlagDescription = `Filter workflow that contains certain filtering
+const listFilterFlagDesc = `Filter workflow that contains certain filtering
 criteria. Use --filter
 <columm_name>=<column_value> pairs. Available
 filters are 'name' and 'status'.
+`
+
+const listDesc = `
+List all workflows and sessions.
+
+The ` + "``list``" + ` command lists workflows and sessions. By default, the list of
+workflows is returned. If you would like to see the list of your open
+interactive sessions, you need to pass the ` + "``--sessions``" + ` command-line
+option.
+
+Example:
+
+  $ reana-client list --all
+
+  $ reana-client list --sessions
+
+  $ reana-client list --verbose --bytes
 `
 
 // Available run statuses
@@ -41,22 +58,7 @@ func newListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all workflows and sessions.",
-		Long: `List all workflows and sessions.
-
-	The ` + "``list``" + ` command lists workflows and sessions. By default, the list of
-	workflows is returned. If you would like to see the list of your open
-	interactive sessions, you need to pass the ` + "``--sessions``" + ` command-line
-	option.
-
-	Example:
-
-	  $ reana-client list --all
-
-	  $ reana-client list --sessions
-
-	  $ reana-client list --verbose --bytes
-
-	  `,
+		Long:  listDesc,
 		Run: func(cmd *cobra.Command, args []string) {
 			token, _ := cmd.Flags().GetString("access-token")
 			if token == "" {
@@ -72,9 +74,9 @@ func newListCmd() *cobra.Command {
 	cmd.Flags().StringP("access-token", "t", "", "Access token of the current user.")
 	cmd.Flags().StringP("workflow", "w", "", "List all runs of the given workflow.")
 	cmd.Flags().StringP("sessions", "s", "", "List all open interactive sessions.")
-	cmd.Flags().String("format", "", listFormatFlagDescription)
+	cmd.Flags().String("format", "", listFormatFlagDesc)
 	cmd.Flags().BoolP("json", "", false, "Get output in JSON format.")
-	cmd.Flags().StringArray("filter", []string{}, listFilterFlagDescription)
+	cmd.Flags().StringArray("filter", []string{}, listFilterFlagDesc)
 
 	return cmd
 }

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -19,19 +19,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const pingDesc = `
+Check connection to REANA server.
+
+The ` + "``ping``" + ` command allows to test connection to REANA server.
+`
+
 func newPingCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ping",
 		Short: "Check connection to REANA server.",
-		Long: `
-	Check connection to REANA server.
-
-	The ` + "``ping``" + ` command allows to test connection to REANA server.
-
-	Examples:
-
-	  $ reana-client ping
-		`,
+		Long:  pingDesc,
 		Run: func(cmd *cobra.Command, args []string) {
 			token, _ := cmd.Flags().GetString("access-token")
 			if token == "" {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -12,21 +12,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "v0.0.0-alpha.1"
+const version = "v0.0.0-alpha.1"
+
+const versionDesc = `
+Show version.
+
+The ` + "``version``" + ` command shows REANA client version.
+`
 
 func newVersionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Show version.",
-		Long: `
-	Show version.
-
-	The ` + "``version``" + ` command shows REANA client version.
-
-	Examples:
-
-	  $ reana-client version
-		`,
+		Long:  versionDesc,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Println(version)
 		},

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,6 +9,8 @@ under the terms of the MIT License; see LICENSE file for more details.
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -26,7 +28,7 @@ func newVersionCmd() *cobra.Command {
 		Short: "Show version.",
 		Long:  versionDesc,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Println(version)
+			fmt.Fprintln(cmd.OutOrStdout(), version)
 		},
 	}
 


### PR DESCRIPTION
Introduces a Makefile that could be used to run some custom build tasks.

Some usage examples:
```
$ make test
$ make build
$ make generate-api-client
```

closes https://github.com/reanahub/reana-client-go/issues/5