### PR TITLE
cli: fix reana server url being verified when not used

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -12,7 +12,14 @@ import (
 	httptransport "github.com/go-openapi/runtime/client"
 )
 
-var ApiClient = newApiClient()
+var apiClient *API
+
+func ApiClient() *API {
+	if apiClient == nil {
+		apiClient = newApiClient()
+	}
+	return apiClient
+}
 
 func newApiClient() *API {
 	// disable certificate security checks

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -59,7 +59,7 @@ func newInfoCmd() *cobra.Command {
 func info(token string, jsonOutput bool) {
 	infoParams := operations.NewInfoParams()
 	infoParams.SetAccessToken(token)
-	infoResp, err := client.ApiClient.Operations.Info(infoParams)
+	infoResp, err := client.ApiClient().Operations.Info(infoParams)
 	if err != nil {
 		fmt.Println("Error: ", err)
 		os.Exit(1)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -96,7 +96,7 @@ func list(cmd *cobra.Command) {
 	listParams.SetStatus(statusFilters)
 	listParams.SetSearch(&searchFilter)
 
-	listResp, err := client.ApiClient.Operations.GetWorkflows(listParams)
+	listResp, err := client.ApiClient().Operations.GetWorkflows(listParams)
 	if err != nil {
 		fmt.Println("Error: ", err)
 		os.Exit(1)

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -52,7 +52,7 @@ func newPingCmd() *cobra.Command {
 func ping(token string, serverURL string) {
 	pingParams := operations.NewGetYouParams()
 	pingParams.SetAccessToken(&token)
-	pingResp, err := client.ApiClient.Operations.GetYou(pingParams)
+	pingResp, err := client.ApiClient().Operations.GetYou(pingParams)
 	if err != nil {
 		fmt.Println("Error: ", err)
 		os.Exit(1)


### PR DESCRIPTION
closes #12

Prevents REANA server URL from being validated when not used, by transforming ApiClient into a function, so that it is only initialized when a command actually needs it