### PR TITLE
cli: implement more flags in the list command

### DIFF
--- a/client/operations/get_files_responses.go
+++ b/client/operations/get_files_responses.go
@@ -385,7 +385,7 @@ type GetFilesOKBodyItemsItems0Size struct {
 	HumanReadable string `json:"human_readable,omitempty"`
 
 	// raw
-	Raw float64 `json:"raw,omitempty"`
+	Raw int64 `json:"raw,omitempty"`
 }
 
 // Validate validates this get files o k body items items0 size

--- a/client/operations/get_workflow_disk_usage_responses.go
+++ b/client/operations/get_workflow_disk_usage_responses.go
@@ -428,7 +428,7 @@ type GetWorkflowDiskUsageOKBodyDiskUsageInfoItems0Size struct {
 	HumanReadable string `json:"human_readable,omitempty"`
 
 	// raw
-	Raw float64 `json:"raw,omitempty"`
+	Raw int64 `json:"raw,omitempty"`
 }
 
 // Validate validates this get workflow disk usage o k body disk usage info items0 size

--- a/client/operations/get_workflows_parameters.go
+++ b/client/operations/get_workflows_parameters.go
@@ -72,6 +72,12 @@ type GetWorkflowsParams struct {
 	*/
 	IncludeProgress *bool
 
+	/* IncludeRetentionRules.
+
+	   Include workspace retention rules of the workflows.
+	*/
+	IncludeRetentionRules *bool
+
 	/* IncludeWorkspaceSize.
 
 	   Include size information of the workspace.
@@ -199,6 +205,17 @@ func (o *GetWorkflowsParams) WithIncludeProgress(includeProgress *bool) *GetWork
 // SetIncludeProgress adds the includeProgress to the get workflows params
 func (o *GetWorkflowsParams) SetIncludeProgress(includeProgress *bool) {
 	o.IncludeProgress = includeProgress
+}
+
+// WithIncludeRetentionRules adds the includeRetentionRules to the get workflows params
+func (o *GetWorkflowsParams) WithIncludeRetentionRules(includeRetentionRules *bool) *GetWorkflowsParams {
+	o.SetIncludeRetentionRules(includeRetentionRules)
+	return o
+}
+
+// SetIncludeRetentionRules adds the includeRetentionRules to the get workflows params
+func (o *GetWorkflowsParams) SetIncludeRetentionRules(includeRetentionRules *bool) {
+	o.IncludeRetentionRules = includeRetentionRules
 }
 
 // WithIncludeWorkspaceSize adds the includeWorkspaceSize to the get workflows params
@@ -337,6 +354,23 @@ func (o *GetWorkflowsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.
 		if qIncludeProgress != "" {
 
 			if err := r.SetQueryParam("include_progress", qIncludeProgress); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.IncludeRetentionRules != nil {
+
+		// query param include_retention_rules
+		var qrIncludeRetentionRules bool
+
+		if o.IncludeRetentionRules != nil {
+			qrIncludeRetentionRules = *o.IncludeRetentionRules
+		}
+		qIncludeRetentionRules := swag.FormatBool(qrIncludeRetentionRules)
+		if qIncludeRetentionRules != "" {
+
+			if err := r.SetQueryParam("include_retention_rules", qIncludeRetentionRules); err != nil {
 				return err
 			}
 		}

--- a/client/operations/get_workflows_responses.go
+++ b/client/operations/get_workflows_responses.go
@@ -300,6 +300,15 @@ type GetWorkflowsOKBodyItemsItems0 struct {
 	// progress
 	Progress *GetWorkflowsOKBodyItemsItems0Progress `json:"progress,omitempty"`
 
+	// session status
+	SessionStatus *string `json:"session_status,omitempty"`
+
+	// session type
+	SessionType *string `json:"session_type,omitempty"`
+
+	// session uri
+	SessionURI *string `json:"session_uri,omitempty"`
+
 	// size
 	Size *GetWorkflowsOKBodyItemsItems0Size `json:"size,omitempty"`
 
@@ -683,7 +692,7 @@ type GetWorkflowsOKBodyItemsItems0ProgressFailed struct {
 	JobIds []string `json:"job_ids"`
 
 	// total
-	Total float64 `json:"total,omitempty"`
+	Total int64 `json:"total,omitempty"`
 }
 
 // Validate validates this get workflows o k body items items0 progress failed
@@ -723,7 +732,7 @@ type GetWorkflowsOKBodyItemsItems0ProgressFinished struct {
 	JobIds []string `json:"job_ids"`
 
 	// total
-	Total float64 `json:"total,omitempty"`
+	Total int64 `json:"total,omitempty"`
 }
 
 // Validate validates this get workflows o k body items items0 progress finished
@@ -763,7 +772,7 @@ type GetWorkflowsOKBodyItemsItems0ProgressRunning struct {
 	JobIds []string `json:"job_ids"`
 
 	// total
-	Total float64 `json:"total,omitempty"`
+	Total int64 `json:"total,omitempty"`
 }
 
 // Validate validates this get workflows o k body items items0 progress running
@@ -803,7 +812,7 @@ type GetWorkflowsOKBodyItemsItems0ProgressTotal struct {
 	JobIds []string `json:"job_ids"`
 
 	// total
-	Total float64 `json:"total,omitempty"`
+	Total int64 `json:"total,omitempty"`
 }
 
 // Validate validates this get workflows o k body items items0 progress total
@@ -843,7 +852,7 @@ type GetWorkflowsOKBodyItemsItems0Size struct {
 	HumanReadable string `json:"human_readable,omitempty"`
 
 	// raw
-	Raw float64 `json:"raw,omitempty"`
+	Raw int64 `json:"raw,omitempty"`
 }
 
 // Validate validates this get workflows o k body items items0 size

--- a/cmd/du.go
+++ b/cmd/du.go
@@ -112,15 +112,15 @@ func displayDuPayload(p *operations.GetWorkflowDiskUsageOKBody, humanReadable bo
 		os.Exit(1)
 	}
 
-	header := []interface{}{"SIZE", "NAME"}
-	var rows [][]interface{}
+	header := []string{"SIZE", "NAME"}
+	var rows [][]any
 
 	for _, diskUsageInfo := range p.DiskUsageInfo {
 		if utils.HasAnyPrefix(diskUsageInfo.Name, utils.FilesBlacklist) {
 			continue
 		}
 
-		var row []interface{}
+		var row []any
 		if humanReadable {
 			row = append(row, diskUsageInfo.Size.HumanReadable)
 		} else {

--- a/utils/display.go
+++ b/utils/display.go
@@ -9,23 +9,42 @@ under the terms of the MIT License; see LICENSE file for more details.
 package utils
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 )
 
-func DisplayTable(header []interface{}, rows [][]interface{}) {
+func DisplayTable(header []string, rows [][]any) {
+	// Convert to table.Row type
 	rowList := make([]table.Row, len(rows))
 	for i, r := range rows {
 		rowList[i] = r
 	}
 
+	headerRow := make(table.Row, len(header))
+	for i, h := range header {
+		headerRow[i] = h
+	}
+
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
-	t.AppendHeader(header)
+	t.AppendHeader(headerRow)
 	t.AppendRows(rowList)
 	t.Style().Options.DrawBorder = false
 	t.Style().Options.SeparateColumns = false
 	t.Style().Options.SeparateHeader = false
 	t.Render()
+}
+
+func DisplayJsonOutput(output any) {
+	byteArray, err := json.MarshalIndent(output, "", "  ")
+
+	if err != nil {
+		fmt.Println("Error: ", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(string(byteArray))
 }


### PR DESCRIPTION
Contributes to #27 

Introduces all the flags functionality, except format, sort and json. Some other features, such as the session headers, were left with a todo mark.
This seemed like a good mark to ask for a review. The following work will be to fix all the TODOs and implement the flags that are still missing