### PR TITLE
ping: add test

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -5,4 +5,5 @@ The list of contributors in alphabetical order:
 
 - `Audrius Mecionis <https://orcid.org/0000-0002-3759-1663>`_
 - `Bruno Rosendo <https://orcid.org/0000-0002-0923-3148>`_
+- `Marco Donadoni <https://orcid.org/0000-0003-2922-5505>`_
 - `Tibor Simko <https://orcid.org/0000-0001-7202-5803>`_

--- a/client/client.go
+++ b/client/client.go
@@ -6,10 +6,10 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
-	"os"
 
 	"github.com/go-openapi/strfmt"
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 
 	httptransport "github.com/go-openapi/runtime/client"
 )
@@ -35,7 +35,7 @@ func newApiClient() (*API, error) {
 	}
 
 	// parse REANA server URL
-	serverURL := os.Getenv("REANA_SERVER_URL")
+	serverURL := viper.GetString("server-url")
 	u, err := url.Parse(serverURL)
 	if err != nil {
 		return nil, err

--- a/cmd/ping_test.go
+++ b/cmd/ping_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reanahub/reana-client-go/utils"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func TestPing(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if accessToken := r.URL.Query().Get("access_token"); accessToken != "1234" {
+			t.Errorf("Expected access token '1234', got '%v'", accessToken)
+		}
+		if r.URL.Path == "/api/you" {
+			w.Header().Add("Content-Type", "application/json")
+			_, err := w.Write([]byte(`{
+				"email": "john.doe@example.org",
+				"reana_server_version": "0.9.0a5"
+			}`))
+			if err != nil {
+				t.Fatalf("Error while writing response body: %v", err)
+			}
+		} else {
+			t.Fatalf("Unexpected request to '%v'", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	viper.Set("server-url", server.URL)
+	defer viper.Reset()
+
+	rootCmd := NewRootCmd()
+	output, err := utils.ExecuteCommand(rootCmd, "ping", "-t", "1234")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(output, "REANA server version: 0.9.0a5") {
+		t.Error("Expected server version in command's output")
+	}
+	if !strings.Contains(output, "Authenticated as: <john.doe@example.org>") {
+		t.Error("Expected user email in command's output")
+	}
+}


### PR DESCRIPTION
Related to #3 

This PR introduces a new test for the `ping` command, mainly to showcase one of the options we have to mock the API calls made to reana-server.

A few comments:
1. We should consider reading the environment variables once at the beginning of the execution and saving them in a config variable accessible by the various commands. In this way, when testing we would not have to set and unset environment variables, which makes our tests fragile and difficult to run in parallel.
2. We should consider wrapping the creation of a test TLS server to make it easier to use and reuse it in many tests
3. To check the command's output from the test, the command needs to print to `cmd.OutOrStdout()`. The output is not captured when using `fmt.Println` (or similar).