### PR TITLE
List sessions headers and json output

### DIFF
--- a/client/operations/get_workflows_responses.go
+++ b/client/operations/get_workflows_responses.go
@@ -301,13 +301,13 @@ type GetWorkflowsOKBodyItemsItems0 struct {
 	Progress *GetWorkflowsOKBodyItemsItems0Progress `json:"progress,omitempty"`
 
 	// session status
-	SessionStatus *string `json:"session_status,omitempty"`
+	SessionStatus string `json:"session_status,omitempty"`
 
 	// session type
-	SessionType *string `json:"session_type,omitempty"`
+	SessionType string `json:"session_type,omitempty"`
 
 	// session uri
-	SessionURI *string `json:"session_uri,omitempty"`
+	SessionURI string `json:"session_uri,omitempty"`
 
 	// size
 	Size *GetWorkflowsOKBodyItemsItems0Size `json:"size,omitempty"`

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -215,14 +215,20 @@ func displayListPayload(
 	}
 
 	if jsonOutput {
-		// TODO Fix json output
-		utils.DisplayJsonOutput(data)
+		jsonData := make([]map[string]any, len(data))
+		for i, row := range data {
+			jsonData[i] = map[string]any{}
+			for j, col := range header {
+				jsonData[i][col] = row[j]
+			}
+		}
+		utils.DisplayJsonOutput(jsonData)
 	} else {
 		utils.DisplayTable(header, data)
 	}
 }
 
-func getWorkflowDuration(workflow *operations.GetWorkflowsOKBodyItemsItems0) string {
+func getWorkflowDuration(workflow *operations.GetWorkflowsOKBodyItemsItems0) any {
 	runStartedAt := workflow.Progress.RunStartedAt
 	runFinishedAt := workflow.Progress.RunFinishedAt
 	if runStartedAt == nil {
@@ -235,8 +241,7 @@ func getWorkflowDuration(workflow *operations.GetWorkflowsOKBodyItemsItems0) str
 	} else {
 		endTime = time.Now()
 	}
-	duration := endTime.Sub(startTime).Round(time.Second).Seconds()
-	return fmt.Sprintf("%g", duration)
+	return endTime.Sub(startTime).Round(time.Second).Seconds()
 }
 
 func buildListHeader(


### PR DESCRIPTION
closes #27 

Adds support for the missing headers in the `list` table, related to interactive sessions.
Additionally, updates swagger API and fixes the json output that was not working correctly