### PR TITLE
cli: add a way to control the output stream

### DIFF
--- a/cmd/close.go
+++ b/cmd/close.go
@@ -52,7 +52,7 @@ func newCloseCmd() *cobra.Command {
 			if err := validation.ValidateWorkflow(workflow); err != nil {
 				return err
 			}
-			if err := close(token, workflow); err != nil {
+			if err := close(cmd, token, workflow); err != nil {
 				return err
 			}
 			return nil
@@ -66,7 +66,7 @@ func newCloseCmd() *cobra.Command {
 	return cmd
 }
 
-func close(token string, workflow string) error {
+func close(cmd *cobra.Command, token string, workflow string) error {
 	closeParams := operations.NewCloseInteractiveSessionParams()
 	closeParams.SetAccessToken(&token)
 	closeParams.SetWorkflowIDOrName(workflow)
@@ -80,6 +80,6 @@ func close(token string, workflow string) error {
 		return fmt.Errorf("interactive session could not be closed:\n%v", err)
 	}
 
-	fmt.Println("Interactive session for workflow", workflow, "was successfully closed")
+	cmd.Println("Interactive session for workflow", workflow, "was successfully closed")
 	return nil
 }

--- a/cmd/du.go
+++ b/cmd/du.go
@@ -110,14 +110,18 @@ func du(cmd *cobra.Command, token string, workflow string) error {
 		return fmt.Errorf("disk usage could not be retrieved:\n%v", err)
 	}
 
-	err = displayDuPayload(duResp.Payload, humanReadable)
+	err = displayDuPayload(cmd, duResp.Payload, humanReadable)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func displayDuPayload(p *operations.GetWorkflowDiskUsageOKBody, humanReadable bool) error {
+func displayDuPayload(
+	cmd *cobra.Command,
+	p *operations.GetWorkflowDiskUsageOKBody,
+	humanReadable bool,
+) error {
 	if len(p.DiskUsageInfo) == 0 {
 		return errors.New("no files matching filter criteria")
 	}
@@ -140,6 +144,6 @@ func displayDuPayload(p *operations.GetWorkflowDiskUsageOKBody, humanReadable bo
 		rows = append(rows, row)
 	}
 
-	utils.DisplayTable(header, rows)
+	utils.DisplayTable(header, rows, cmd.OutOrStdout())
 	return nil
 }

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -77,7 +77,7 @@ func info(cmd *cobra.Command, token string) error {
 
 	p := infoResp.Payload
 	if jsonOutput {
-		err := utils.DisplayJsonOutput(p)
+		err := utils.DisplayJsonOutput(p, cmd.OutOrStdout())
 		if err != nil {
 			return err
 		}
@@ -86,7 +86,7 @@ func info(cmd *cobra.Command, token string) error {
 			fmt.Sprintf("Default workspace: %s \n", p.DefaultWorkspace.Value) +
 			fmt.Sprintf("List of available workspaces: %s \n", strings.Join(p.WorkspacesAvailable.Value, ", "))
 
-		fmt.Print(response)
+		cmd.Print(response)
 	}
 	return nil
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -170,6 +170,7 @@ func list(cmd *cobra.Command, token string, serverURL string) error {
 	)
 	parsedFormatFilters := utils.ParseFormatParameters(formatFilters)
 	err = displayListPayload(
+		cmd,
 		listResp.Payload,
 		header,
 		parsedFormatFilters,
@@ -187,6 +188,7 @@ func list(cmd *cobra.Command, token string, serverURL string) error {
 }
 
 func displayListPayload(
+	cmd *cobra.Command,
 	p *operations.GetWorkflowsOKBody,
 	header []string,
 	formatFilters map[string]string,
@@ -254,7 +256,7 @@ func displayListPayload(
 
 	err := sortListData(data, header, sortColumn)
 	if err != nil {
-		fmt.Printf("Warning: sort operation was aborted, \"%v\"\n", err)
+		cmd.PrintErrf("Warning: sort operation was aborted, \"%v\"\n", err)
 	}
 	utils.FormatData(&data, &header, formatFilters)
 
@@ -267,12 +269,12 @@ func displayListPayload(
 			}
 		}
 
-		err := utils.DisplayJsonOutput(jsonData)
+		err := utils.DisplayJsonOutput(jsonData, cmd.OutOrStdout())
 		if err != nil {
 			return err
 		}
 	} else {
-		utils.DisplayTable(header, data)
+		utils.DisplayTable(header, data, cmd.OutOrStdout())
 	}
 	return nil
 }

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -114,8 +114,8 @@ func open(
 		return fmt.Errorf("interactive session could not be opened:\n%v", err)
 	}
 
-	fmt.Println("Interactive session opened successfully")
-	fmt.Println(utils.FormatSessionURI(serverURL, openResp.Payload.Path, token))
-	fmt.Println("It could take several minutes to start the interactive session.")
+	cmd.Println("Interactive session opened successfully")
+	cmd.Println(utils.FormatSessionURI(serverURL, openResp.Payload.Path, token))
+	cmd.Println("It could take several minutes to start the interactive session.")
 	return nil
 }

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -43,7 +43,7 @@ func newPingCmd() *cobra.Command {
 			if err := validation.ValidateServerURL(serverURL); err != nil {
 				return err
 			}
-			if err := ping(token, serverURL); err != nil {
+			if err := ping(cmd, token, serverURL); err != nil {
 				return err
 			}
 			return nil
@@ -55,7 +55,7 @@ func newPingCmd() *cobra.Command {
 	return cmd
 }
 
-func ping(token string, serverURL string) error {
+func ping(cmd *cobra.Command, token string, serverURL string) error {
 	pingParams := operations.NewGetYouParams()
 	pingParams.SetAccessToken(&token)
 
@@ -75,6 +75,6 @@ func ping(token string, serverURL string) error {
 		fmt.Sprintf("Authenticated as: <%s> \n", p.Email) +
 		fmt.Sprintf("Status: %s ", "Connected")
 
-	fmt.Println(response)
+	cmd.Println(response)
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,8 @@ under the terms of the MIT License; see LICENSE file for more details.
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
@@ -19,6 +21,8 @@ func NewRootCmd() *cobra.Command {
 		Long:         "REANA client for interacting with REANA server.",
 		SilenceUsage: true,
 	}
+
+	cmd.SetOut(os.Stdout)
 
 	cmd.PersistentFlags().BoolP("loglevel", "l", false, "Sets log level [DEBUG|INFO|WARNING]")
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,8 +9,6 @@ under the terms of the MIT License; see LICENSE file for more details.
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -28,7 +26,7 @@ func newVersionCmd() *cobra.Command {
 		Short: "Show version.",
 		Long:  versionDesc,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Fprintln(cmd.OutOrStdout(), version)
+			cmd.Println(version)
 		},
 	}
 

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 func TestVersionCmd(t *testing.T) {
-	cmd := NewRootCmd()
-	out, _ := utils.ExecuteCommand(cmd, "version")
+	cmd := newVersionCmd()
+	out, _ := utils.ExecuteCommand(cmd)
 
 	if strings.TrimSpace(out) != version {
 		t.Fatalf("Expected: \"%s\", got: \"%s\"", version, out)

--- a/utils/display.go
+++ b/utils/display.go
@@ -11,12 +11,12 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
-	"os"
+	"io"
 
 	"github.com/jedib0t/go-pretty/v6/table"
 )
 
-func DisplayTable(header []string, rows [][]any) {
+func DisplayTable(header []string, rows [][]any, out io.Writer) {
 	// Convert to table.Row type
 	rowList := make([]table.Row, len(rows))
 	for i, r := range rows {
@@ -29,7 +29,7 @@ func DisplayTable(header []string, rows [][]any) {
 	}
 
 	t := table.NewWriter()
-	t.SetOutputMirror(os.Stdout)
+	t.SetOutputMirror(out)
 	t.AppendHeader(headerRow)
 	t.AppendRows(rowList)
 	t.Style().Options.DrawBorder = false
@@ -38,13 +38,16 @@ func DisplayTable(header []string, rows [][]any) {
 	t.Render()
 }
 
-func DisplayJsonOutput(output any) error {
+func DisplayJsonOutput(output any, out io.Writer) error {
 	byteArray, err := json.MarshalIndent(output, "", "  ")
 
 	if err != nil {
 		return fmt.Errorf("failed to display json output:\n%v", err)
 	}
 
-	fmt.Println(string(byteArray))
+	_, err = fmt.Fprintln(out, string(byteArray))
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -43,13 +43,13 @@ func GetRunStatuses(includeDeleted bool) []string {
 	return runStatuses
 }
 
-func ExecuteCommand(root *cobra.Command, args ...string) (output string, err error) {
+func ExecuteCommand(cmd *cobra.Command, args ...string) (output string, err error) {
 	buf := new(bytes.Buffer)
-	root.SetOut(buf)
-	root.SetErr(buf)
-	root.SetArgs(args)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs(args)
 
-	err = root.Execute()
+	err = cmd.Execute()
 
 	return buf.String(), err
 }


### PR DESCRIPTION
closes #24

The strategy was:
- Change the Cobra's output to `os.Stdout`, since it uses `Stderr` by default. This only needed to be done at the root command
- In every command, change the `fmt` commands to `cmd` (e.g. `cmd.PrintLn()`)
- In `utils` or other functions without accces to `cmd`, pass the output through a parameter and use it