### PR TITLE
cli: add display message utility

### DIFF
--- a/cmd/close.go
+++ b/cmd/close.go
@@ -9,9 +9,11 @@ under the terms of the MIT License; see LICENSE file for more details.
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"reanahub/reana-client-go/client"
 	"reanahub/reana-client-go/client/operations"
+	"reanahub/reana-client-go/utils"
 	"reanahub/reana-client-go/validation"
 
 	log "github.com/sirupsen/logrus"
@@ -96,6 +98,11 @@ func (o *closeOptions) run(cmd *cobra.Command) error {
 		return err
 	}
 
-	cmd.Println("Interactive session for workflow", o.workflow, "was successfully closed")
+	utils.DisplayMessage(
+		fmt.Sprintf("Interactive session for workflow %s was successfully closed", o.workflow),
+		utils.Success,
+		false,
+		cmd.OutOrStdout(),
+	)
 	return nil
 }

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -120,7 +120,12 @@ func (o *openOptions) run(cmd *cobra.Command) error {
 		return err
 	}
 
-	cmd.Println("Interactive session opened successfully")
+	utils.DisplayMessage(
+		"Interactive session opened successfully",
+		utils.Success,
+		false,
+		cmd.OutOrStdout(),
+	)
 	cmd.Println(utils.FormatSessionURI(o.serverURL, openResp.Payload.Path, o.token))
 	cmd.Println("It could take several minutes to start the interactive session.")
 	return nil

--- a/utils/display.go
+++ b/utils/display.go
@@ -14,7 +14,25 @@ import (
 	"io"
 
 	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
 )
+
+type MessageType int
+
+const (
+	Success MessageType = iota
+	Warning
+	Error
+	Info
+)
+
+func (m MessageType) String() string {
+	return []string{"SUCCESS", "WARNING", "ERROR", "INFO"}[m]
+}
+
+func (m MessageType) Color() text.Color {
+	return []text.Color{text.FgGreen, text.FgYellow, text.FgRed, text.FgCyan}[m]
+}
 
 func DisplayTable(header []string, rows [][]any, out io.Writer) {
 	// Convert to table.Row type
@@ -50,4 +68,28 @@ func DisplayJsonOutput(output any, out io.Writer) error {
 		return err
 	}
 	return nil
+}
+
+func DisplayMessage(message string, messageType MessageType, indented bool, out io.Writer) {
+	prefix := "==>"
+	if indented {
+		prefix = "  ->"
+	}
+
+	if messageType == Info && !indented {
+		msg := text.Bold.Sprintf("%s %s\n", prefix, message)
+		fmt.Fprint(out, msg)
+		return
+	}
+
+	prefixTpl := colorizeMessage(
+		fmt.Sprintf("%s %s: ", prefix, messageType),
+		messageType,
+	)
+
+	fmt.Fprintf(out, "%s%s\n", prefixTpl, message)
+}
+
+func colorizeMessage(msg string, msgType MessageType) string {
+	return text.Colors{msgType.Color(), text.Bold}.Sprint(msg)
 }

--- a/utils/display_test.go
+++ b/utils/display_test.go
@@ -1,0 +1,85 @@
+/*
+This file is part of REANA.
+Copyright (C) 2022 CERN.
+
+REANA is free software; you can redistribute it and/or modify it
+under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+package utils
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/jedib0t/go-pretty/v6/text"
+)
+
+func TestDisplayMessage(t *testing.T) {
+	tests := []struct {
+		msg      string
+		msgType  MessageType
+		indented bool
+		expected string
+	}{
+		{
+			msg:      "test success",
+			msgType:  Success,
+			indented: false,
+			expected: text.Colors{
+				text.FgGreen,
+				text.Bold,
+			}.Sprint(
+				"==> SUCCESS: ",
+			) + "test success\n",
+		},
+		{
+			msg:      "test success indented",
+			msgType:  Success,
+			indented: true,
+			expected: text.Colors{
+				text.FgGreen,
+				text.Bold,
+			}.Sprint(
+				"  -> SUCCESS: ",
+			) + "test success indented\n",
+		},
+		{
+			msg:      "test error",
+			msgType:  Error,
+			indented: false,
+			expected: text.Colors{
+				text.FgRed,
+				text.Bold,
+			}.Sprint(
+				"==> ERROR: ",
+			) + "test error\n",
+		},
+		{
+			msg:      "test info",
+			msgType:  Info,
+			indented: false,
+			expected: text.Bold.Sprint("==> test info\n"), // should be bold without any color
+		},
+		{
+			msg:      "test info indented",
+			msgType:  Info,
+			indented: true,
+			expected: text.Colors{
+				text.FgCyan,
+				text.Bold,
+			}.Sprint(
+				"  -> INFO: ",
+			) + "test info indented\n",
+		},
+	}
+
+	for _, test := range tests {
+		buf := new(bytes.Buffer)
+		DisplayMessage(test.msg, test.msgType, test.indented, buf)
+		result := buf.String()
+		if result != test.expected {
+			t.Fatalf("Expected: \"%s\", got: \"%s\"", test.expected, result)
+		}
+	}
+}


### PR DESCRIPTION
closes https://github.com/reanahub/reana-client-go/issues/2

Built on top of [cli: implement loglevel flag](https://github.com/reanahub/reana-client-go/pull/54)

This PR introduces an utility similar to [display_message() in Python client](https://github.com/reanahub/reana-client/blob/master/reana_client/printer.py#L21) to colorize the output in `reana-client-go`