### PR TITLE
cli: add missing logs and messages colors

### DIFF
--- a/cmd/close.go
+++ b/cmd/close.go
@@ -71,7 +71,7 @@ func (o *closeOptions) run(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	log.Infof("Closing an interactive session on '%s'", o.workflow)
+	log.Infof("Closing an interactive session on %s", o.workflow)
 	_, err = api.Operations.CloseInteractiveSession(closeParams)
 	if err != nil {
 		return err

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -14,6 +14,8 @@ import (
 	"reanahub/reana-client-go/utils"
 	"reanahub/reana-client-go/validation"
 
+	"github.com/jedib0t/go-pretty/v6/text"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -95,7 +97,7 @@ func (o *openOptions) run(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	log.Infof("Opening an interactive session on '%s'", o.workflow)
+	log.Infof("Opening an interactive session on %s", o.workflow)
 	openResp, err := api.Operations.OpenInteractiveSession(openParams)
 	if err != nil {
 		return err
@@ -107,7 +109,8 @@ func (o *openOptions) run(cmd *cobra.Command) error {
 		false,
 		cmd.OutOrStdout(),
 	)
-	cmd.Println(utils.FormatSessionURI(o.serverURL, openResp.Payload.Path, o.token))
+	sessionURI := utils.FormatSessionURI(o.serverURL, openResp.Payload.Path, o.token)
+	utils.PrintColorable(sessionURI+"\n", cmd.OutOrStdout(), text.FgGreen)
 	cmd.Println("It could take several minutes to start the interactive session.")
 	return nil
 }

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -11,6 +11,8 @@ package cmd
 import (
 	"fmt"
 
+	log "github.com/sirupsen/logrus"
+
 	"reanahub/reana-client-go/client"
 	"reanahub/reana-client-go/client/operations"
 
@@ -54,6 +56,8 @@ func (o *pingOptions) run(cmd *cobra.Command) error {
 	pingParams := operations.NewGetYouParams()
 	pingParams.SetAccessToken(&o.token)
 
+	log.Info("Connecting to ", o.serverURL)
+
 	api, err := client.ApiClient()
 	if err != nil {
 		return err
@@ -71,5 +75,6 @@ func (o *pingOptions) run(cmd *cobra.Command) error {
 		fmt.Sprintf("Status: %s ", "Connected")
 
 	cmd.Println(response)
+
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -14,10 +14,11 @@ Use --help for more information.
 package main
 
 import (
-	"fmt"
 	"os"
 	"reanahub/reana-client-go/cmd"
 	"reanahub/reana-client-go/utils"
+
+	log "github.com/sirupsen/logrus"
 )
 
 func main() {
@@ -25,8 +26,9 @@ func main() {
 	err := rootCmd.Execute()
 
 	if err != nil {
+		log.Debug(err)
 		err := utils.HandleApiError(err)
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err.Error())
+		utils.DisplayMessage(err.Error(), utils.Error, false, os.Stderr)
 		os.Exit(1)
 	}
 }

--- a/utils/display.go
+++ b/utils/display.go
@@ -37,6 +37,13 @@ func (m MessageType) Color() text.Color {
 	return []text.Color{text.FgGreen, text.FgYellow, text.FgRed, text.FgCyan}[m]
 }
 
+// JobStatusToColor Maps the different job status to a matching color. Can be used with PrintColorable.
+var JobStatusToColor = map[string]text.Color{
+	"failed":   text.FgRed,
+	"finished": text.FgGreen,
+	"running":  text.FgCyan,
+}
+
 // DisplayTable takes a header and the respective rows, and formats them in a table.
 // Instead of writing to stdout, it uses the provided io.Writer.
 func DisplayTable[T any](header []string, rows [][]T, out io.Writer) {
@@ -95,16 +102,18 @@ func DisplayMessage(message string, messageType MessageType, indented bool, out 
 		return
 	}
 
-	prefixTpl := colorizeMessage(
+	PrintColorable(
 		fmt.Sprintf("%s %s: ", prefix, messageType),
-		messageType,
+		out,
+		messageType.Color(),
+		text.Bold,
 	)
-
-	fmt.Fprintf(out, "%s%s\n", prefixTpl, message)
+	fmt.Fprintln(out, message)
 }
 
-// colorizeMessage returns the prefix used to colorize messages before printing them.
-// The prefix is chosen according to the given msgType.
-func colorizeMessage(msg string, msgType MessageType) string {
-	return text.Colors{msgType.Color(), text.Bold}.Sprint(msg)
+// PrintColorable prints a colorable string, according to the colorOptions provided.
+func PrintColorable(str string, out io.Writer, colorOptions ...text.Color) {
+	var colors text.Colors
+	colors = append(colors, colorOptions...)
+	fmt.Fprint(out, colors.Sprint(str))
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -138,16 +138,6 @@ func LogCmdFlags(cmd *cobra.Command) {
 	})
 }
 
-// RemoveFromSlice removes an element from the slice and returns the updated one.
-func RemoveFromSlice[T comparable](slice []T, item T) []T {
-	for i, elem := range slice {
-		if elem == item {
-			return append(slice[:i], slice[i+1:]...)
-		}
-	}
-	return slice
-}
-
 // HandleApiError Handles API Error response which contains a payload with a message
 // Returns the original error when this doesn't happen
 func HandleApiError(err error) error {


### PR DESCRIPTION
Adds logs and colors to the messages that were missing them, according mostly to the Python client.

closes https://github.com/reanahub/reana-client-go/issues/62