### PR TITLE
cli: instantiate viper instead of using a singleton

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -14,8 +14,8 @@ import (
 	httptransport "github.com/go-openapi/runtime/client"
 )
 
-// ApiClient provides a new API client used to communicate with the REANA server.
-func ApiClient() (*API, error) {
+// NewApiClient provides a new API client used to communicate with the REANA server.
+func NewApiClient(viper *viper.Viper) (*API, error) {
 	// disable certificate security checks
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
 		InsecureSkipVerify: true,

--- a/cmd/close.go
+++ b/cmd/close.go
@@ -37,7 +37,7 @@ type closeOptions struct {
 }
 
 // newCloseCmd creates a command to close an interactive session.
-func newCloseCmd() *cobra.Command {
+func newCloseCmd(api *client.API) *cobra.Command {
 	o := &closeOptions{}
 
 	cmd := &cobra.Command{
@@ -46,7 +46,7 @@ func newCloseCmd() *cobra.Command {
 		Long:  closeDesc,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return o.run(cmd)
+			return o.run(cmd, api)
 		},
 	}
 
@@ -62,17 +62,13 @@ func newCloseCmd() *cobra.Command {
 	return cmd
 }
 
-func (o *closeOptions) run(cmd *cobra.Command) error {
+func (o *closeOptions) run(cmd *cobra.Command, api *client.API) error {
 	closeParams := operations.NewCloseInteractiveSessionParams()
 	closeParams.SetAccessToken(&o.token)
 	closeParams.SetWorkflowIDOrName(o.workflow)
 
-	api, err := client.ApiClient()
-	if err != nil {
-		return err
-	}
 	log.Infof("Closing an interactive session on %s", o.workflow)
-	_, err = api.Operations.CloseInteractiveSession(closeParams)
+	_, err := api.Operations.CloseInteractiveSession(closeParams)
 	if err != nil {
 		return err
 	}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -10,6 +10,7 @@ package cmd
 
 import (
 	"fmt"
+	"reanahub/reana-client-go/client"
 	"reanahub/reana-client-go/pkg/displayer"
 	"reanahub/reana-client-go/pkg/workflows"
 
@@ -39,7 +40,7 @@ type deleteOptions struct {
 }
 
 // newDeleteCmd creates a command to delete a workflow.
-func newDeleteCmd() *cobra.Command {
+func newDeleteCmd(api *client.API) *cobra.Command {
 	o := &deleteOptions{}
 
 	cmd := &cobra.Command{
@@ -48,7 +49,7 @@ func newDeleteCmd() *cobra.Command {
 		Long:  deleteDesc,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return o.run(cmd)
+			return o.run(cmd, api)
 		},
 	}
 
@@ -72,8 +73,9 @@ func newDeleteCmd() *cobra.Command {
 	return cmd
 }
 
-func (o *deleteOptions) run(cmd *cobra.Command) error {
+func (o *deleteOptions) run(cmd *cobra.Command, api *client.API) error {
 	err := workflows.UpdateStatus(
+		api,
 		o.token,
 		o.workflow,
 		"deleted",

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -48,7 +48,7 @@ type diffOptions struct {
 }
 
 // newDiffCmd creates a command to show diff between two workflows.
-func newDiffCmd() *cobra.Command {
+func newDiffCmd(api *client.API) *cobra.Command {
 	o := &diffOptions{}
 
 	cmd := &cobra.Command{
@@ -59,7 +59,7 @@ func newDiffCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			o.workflowA = args[0]
 			o.workflowB = args[1]
-			return o.run(cmd)
+			return o.run(cmd, api)
 		},
 	}
 
@@ -74,7 +74,7 @@ files in the two workspaces are shown.`)
 	return cmd
 }
 
-func (o *diffOptions) run(cmd *cobra.Command) error {
+func (o *diffOptions) run(cmd *cobra.Command, api *client.API) error {
 	diffParams := operations.NewGetWorkflowDiffParams()
 	diffParams.SetAccessToken(&o.token)
 	diffParams.SetWorkflowIDOrNamea(o.workflowA)
@@ -83,10 +83,6 @@ func (o *diffOptions) run(cmd *cobra.Command) error {
 	contextLines := fmt.Sprintf("%d", o.unified)
 	diffParams.SetContextLines(&contextLines)
 
-	api, err := client.ApiClient()
-	if err != nil {
-		return err
-	}
 	diffResp, err := api.Operations.GetWorkflowDiff(diffParams)
 	if err != nil {
 		return err

--- a/cmd/du.go
+++ b/cmd/du.go
@@ -48,7 +48,7 @@ type duOptions struct {
 }
 
 // newDuCmd creates a command to get workspace disk usage.
-func newDuCmd() *cobra.Command {
+func newDuCmd(api *client.API) *cobra.Command {
 	o := &duOptions{}
 
 	cmd := &cobra.Command{
@@ -57,7 +57,7 @@ func newDuCmd() *cobra.Command {
 		Long:  duDesc,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return o.run(cmd)
+			return o.run(cmd, api)
 		},
 	}
 
@@ -84,7 +84,7 @@ func newDuCmd() *cobra.Command {
 	return cmd
 }
 
-func (o *duOptions) run(cmd *cobra.Command) error {
+func (o *duOptions) run(cmd *cobra.Command, api *client.API) error {
 	filters, err := filterer.NewFilters(nil, config.DuMultiFilters, o.filter)
 	if err != nil {
 		return err
@@ -103,10 +103,6 @@ func (o *duOptions) run(cmd *cobra.Command) error {
 	}
 	duParams.SetParameters(additionalParams)
 
-	api, err := client.ApiClient()
-	if err != nil {
-		return err
-	}
 	duResp, err := api.Operations.GetWorkflowDiskUsage(duParams)
 	if err != nil {
 		return err

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -32,7 +32,7 @@ type infoOptions struct {
 }
 
 // newInfoCmd creates a command to list cluster general information.
-func newInfoCmd() *cobra.Command {
+func newInfoCmd(api *client.API) *cobra.Command {
 	o := &infoOptions{}
 
 	cmd := &cobra.Command{
@@ -41,7 +41,7 @@ func newInfoCmd() *cobra.Command {
 		Long:  infoDesc,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return o.run(cmd)
+			return o.run(cmd, api)
 		},
 	}
 
@@ -52,14 +52,10 @@ func newInfoCmd() *cobra.Command {
 	return cmd
 }
 
-func (o *infoOptions) run(cmd *cobra.Command) error {
+func (o *infoOptions) run(cmd *cobra.Command, api *client.API) error {
 	infoParams := operations.NewInfoParams()
 	infoParams.SetAccessToken(o.token)
 
-	api, err := client.ApiClient()
-	if err != nil {
-		return err
-	}
 	infoResp, err := api.Operations.Info(infoParams)
 	if err != nil {
 		return err

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -74,7 +74,7 @@ type listOptions struct {
 }
 
 // newListCmd creates a new command for listing workflows and sessions.
-func newListCmd() *cobra.Command {
+func newListCmd(api *client.API, viper *viper.Viper) *cobra.Command {
 	o := &listOptions{}
 
 	cmd := &cobra.Command{
@@ -84,7 +84,7 @@ func newListCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			o.serverURL = viper.GetString("server-url")
-			return o.run(cmd)
+			return o.run(cmd, api)
 		},
 	}
 
@@ -149,7 +149,7 @@ In case a workflow is in progress, its duration as of now will be shown.`,
 	return cmd
 }
 
-func (o *listOptions) run(cmd *cobra.Command) error {
+func (o *listOptions) run(cmd *cobra.Command, api *client.API) error {
 	var runType string
 	if o.listSessions {
 		runType = "interactive"
@@ -181,10 +181,6 @@ func (o *listOptions) run(cmd *cobra.Command) error {
 		listParams.SetIncludeWorkspaceSize(&o.includeWorkspaceSize)
 	}
 
-	api, err := client.ApiClient()
-	if err != nil {
-		return err
-	}
 	listResp, err := api.Operations.GetWorkflows(listParams)
 	if err != nil {
 		return err

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -75,7 +75,7 @@ type logsOptions struct {
 }
 
 // newLogsCmd creates a command to get workflow logs.
-func newLogsCmd() *cobra.Command {
+func newLogsCmd(api *client.API) *cobra.Command {
 	o := &logsOptions{}
 
 	cmd := &cobra.Command{
@@ -84,7 +84,7 @@ func newLogsCmd() *cobra.Command {
 		Long:  logsDesc,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return o.run(cmd)
+			return o.run(cmd, api)
 		},
 	}
 
@@ -105,7 +105,7 @@ func newLogsCmd() *cobra.Command {
 	return cmd
 }
 
-func (o *logsOptions) run(cmd *cobra.Command) error {
+func (o *logsOptions) run(cmd *cobra.Command, api *client.API) error {
 	filters, err := parseLogsFilters(o.filters)
 	if err != nil {
 		return err
@@ -124,10 +124,6 @@ func (o *logsOptions) run(cmd *cobra.Command) error {
 		logsParams.SetSize(&o.size)
 	}
 
-	api, err := client.ApiClient()
-	if err != nil {
-		return err
-	}
 	logsResp, err := api.Operations.GetWorkflowLogs(logsParams)
 	if err != nil {
 		return err

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -71,7 +71,7 @@ type lsOptions struct {
 }
 
 // newLsCmd creates a command to list workspace files.
-func newLsCmd() *cobra.Command {
+func newLsCmd(api *client.API, viper *viper.Viper) *cobra.Command {
 	o := &lsOptions{}
 
 	cmd := &cobra.Command{
@@ -84,7 +84,7 @@ func newLsCmd() *cobra.Command {
 			if len(args) > 0 {
 				o.fileName = args[0]
 			}
-			return o.run(cmd)
+			return o.run(cmd, api)
 		},
 	}
 
@@ -116,7 +116,8 @@ func newLsCmd() *cobra.Command {
 	return cmd
 }
 
-func (o *lsOptions) run(cmd *cobra.Command) error {
+// Run runs the ls command with the options provided by o.
+func (o *lsOptions) run(cmd *cobra.Command, api *client.API) error {
 	header := []string{"name", "size", "last-modified"}
 
 	filters, err := filterer.NewFilters(nil, header, o.filters)
@@ -140,10 +141,6 @@ func (o *lsOptions) run(cmd *cobra.Command) error {
 		lsParams.SetSize(&o.size)
 	}
 
-	api, err := client.ApiClient()
-	if err != nil {
-		return err
-	}
 	lsResp, err := api.Operations.GetFiles(lsParams)
 	if err != nil {
 		return err

--- a/cmd/mv.go
+++ b/cmd/mv.go
@@ -35,7 +35,7 @@ type mvOptions struct {
 }
 
 // newMvCmd creates a command to move files within workspace.
-func newMvCmd() *cobra.Command {
+func newMvCmd(api *client.API) *cobra.Command {
 	o := &mvOptions{}
 
 	cmd := &cobra.Command{
@@ -46,7 +46,7 @@ func newMvCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			o.source = args[0]
 			o.target = args[1]
-			return o.run(cmd)
+			return o.run(cmd, api)
 		},
 	}
 
@@ -62,18 +62,14 @@ func newMvCmd() *cobra.Command {
 	return cmd
 }
 
-func (o *mvOptions) run(cmd *cobra.Command) error {
+func (o *mvOptions) run(cmd *cobra.Command, api *client.API) error {
 	mvParams := operations.NewMoveFilesParams()
 	mvParams.SetAccessToken(&o.token)
 	mvParams.SetWorkflowIDOrName(o.workflow)
 	mvParams.SetSource(o.source)
 	mvParams.SetTarget(o.target)
 
-	api, err := client.ApiClient()
-	if err != nil {
-		return err
-	}
-	_, err = api.Operations.MoveFiles(mvParams)
+	_, err := api.Operations.MoveFiles(mvParams)
 	if err != nil {
 		return err
 	}

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -48,7 +48,7 @@ type openOptions struct {
 }
 
 // newOpenCmd creates a command to open an interactive session inside the workspace.
-func newOpenCmd() *cobra.Command {
+func newOpenCmd(api *client.API, viper *viper.Viper) *cobra.Command {
 	o := &openOptions{}
 
 	cmd := &cobra.Command{
@@ -69,7 +69,7 @@ func newOpenCmd() *cobra.Command {
 			); err != nil {
 				return err
 			}
-			return o.run(cmd)
+			return o.run(cmd, api)
 		},
 	}
 
@@ -86,7 +86,7 @@ func newOpenCmd() *cobra.Command {
 	return cmd
 }
 
-func (o *openOptions) run(cmd *cobra.Command) error {
+func (o *openOptions) run(cmd *cobra.Command, api *client.API) error {
 	openParams := operations.NewOpenInteractiveSessionParams()
 	openParams.SetAccessToken(&o.token)
 	openParams.SetWorkflowIDOrName(o.workflow)
@@ -95,10 +95,6 @@ func (o *openOptions) run(cmd *cobra.Command) error {
 		operations.OpenInteractiveSessionBody{Image: o.image},
 	)
 
-	api, err := client.ApiClient()
-	if err != nil {
-		return err
-	}
 	log.Infof("Opening an interactive session on %s", o.workflow)
 	openResp, err := api.Operations.OpenInteractiveSession(openParams)
 	if err != nil {

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -30,7 +30,7 @@ type pingOptions struct {
 }
 
 // newPingCmd creates a command to ping the REANA server.
-func newPingCmd() *cobra.Command {
+func newPingCmd(api *client.API, viper *viper.Viper) *cobra.Command {
 	o := &pingOptions{}
 
 	cmd := &cobra.Command{
@@ -40,7 +40,7 @@ func newPingCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			o.serverURL = viper.GetString("server-url")
-			return o.run(cmd)
+			return o.run(cmd, api)
 		},
 	}
 
@@ -50,14 +50,10 @@ func newPingCmd() *cobra.Command {
 	return cmd
 }
 
-func (o *pingOptions) run(cmd *cobra.Command) error {
+func (o *pingOptions) run(cmd *cobra.Command, api *client.API) error {
 	pingParams := operations.NewGetYouParams()
 	pingParams.SetAccessToken(&o.token)
 
-	api, err := client.ApiClient()
-	if err != nil {
-		return err
-	}
 	pingResp, err := api.Operations.GetYou(pingParams)
 	if err != nil {
 		return err

--- a/cmd/quota_show.go
+++ b/cmd/quota_show.go
@@ -61,7 +61,7 @@ type quotaShowOptions struct {
 }
 
 // newQuotaShowCmd creates a command to show user quota.
-func newQuotaShowCmd() *cobra.Command {
+func newQuotaShowCmd(api *client.API) *cobra.Command {
 	o := &quotaShowOptions{}
 
 	cmd := &cobra.Command{
@@ -84,7 +84,7 @@ func newQuotaShowCmd() *cobra.Command {
 			} else {
 				o.unspecifiedReport = true
 			}
-			return o.run(cmd)
+			return o.run(cmd, api)
 		},
 	}
 
@@ -106,14 +106,10 @@ func newQuotaShowCmd() *cobra.Command {
 	return cmd
 }
 
-func (o *quotaShowOptions) run(cmd *cobra.Command) error {
+func (o *quotaShowOptions) run(cmd *cobra.Command, api *client.API) error {
 	quotaParams := operations.NewGetYouParams()
 	quotaParams.SetAccessToken(&o.token)
 
-	api, err := client.ApiClient()
-	if err != nil {
-		return err
-	}
 	quotaResp, err := api.Operations.GetYou(quotaParams)
 	if err != nil {
 		return err

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -38,7 +38,7 @@ type rmOptions struct {
 }
 
 // newRmCmd creates a command to delete files from workspace.
-func newRmCmd() *cobra.Command {
+func newRmCmd(api *client.API) *cobra.Command {
 	o := &rmOptions{}
 
 	cmd := &cobra.Command{
@@ -48,7 +48,7 @@ func newRmCmd() *cobra.Command {
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			o.fileNames = args
-			return o.run(cmd)
+			return o.run(cmd, api)
 		},
 	}
 
@@ -64,12 +64,7 @@ func newRmCmd() *cobra.Command {
 	return cmd
 }
 
-func (o *rmOptions) run(cmd *cobra.Command) error {
-	api, err := client.ApiClient()
-	if err != nil {
-		return err
-	}
-
+func (o *rmOptions) run(cmd *cobra.Command, api *client.API) error {
 	hasError := false
 	for _, fileName := range o.fileNames {
 		rmParams := operations.NewDeleteFileParams()

--- a/cmd/secrets_add.go
+++ b/cmd/secrets_add.go
@@ -47,7 +47,7 @@ type secretsAddOptions struct {
 }
 
 // newSecretsAddCmd creates a command to add secrets from literal string or from file.
-func newSecretsAddCmd() *cobra.Command {
+func newSecretsAddCmd(api *client.API) *cobra.Command {
 	o := &secretsAddOptions{}
 
 	cmd := &cobra.Command{
@@ -66,7 +66,7 @@ func newSecretsAddCmd() *cobra.Command {
 					return fmt.Errorf("invalid value for '--file': %s", err.Error())
 				}
 			}
-			return o.run(cmd)
+			return o.run(cmd, api)
 		},
 	}
 
@@ -80,7 +80,7 @@ e.g. PASSWORD=password123`)
 	return cmd
 }
 
-func (o *secretsAddOptions) run(cmd *cobra.Command) error {
+func (o *secretsAddOptions) run(cmd *cobra.Command, api *client.API) error {
 	secrets, secretNames, err := parseSecrets(o.envSecrets, o.fileSecrets)
 	if err != nil {
 		return err
@@ -91,10 +91,6 @@ func (o *secretsAddOptions) run(cmd *cobra.Command) error {
 	addSecretsParams.SetOverwrite(&o.overwrite)
 	addSecretsParams.SetSecrets(secrets)
 
-	api, err := client.ApiClient()
-	if err != nil {
-		return err
-	}
 	_, err = api.Operations.AddSecrets(addSecretsParams)
 	if err != nil {
 		return err

--- a/cmd/secrets_delete.go
+++ b/cmd/secrets_delete.go
@@ -32,7 +32,7 @@ type secretsDeleteOptions struct {
 }
 
 // newSecretsDeleteCmd creates a command to delete user secrets by name.
-func newSecretsDeleteCmd() *cobra.Command {
+func newSecretsDeleteCmd(api *client.API) *cobra.Command {
 	o := &secretsDeleteOptions{}
 
 	cmd := &cobra.Command{
@@ -42,7 +42,7 @@ func newSecretsDeleteCmd() *cobra.Command {
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			o.secrets = args
-			return o.run(cmd)
+			return o.run(cmd, api)
 		},
 	}
 
@@ -52,15 +52,11 @@ func newSecretsDeleteCmd() *cobra.Command {
 	return cmd
 }
 
-func (o *secretsDeleteOptions) run(cmd *cobra.Command) error {
+func (o *secretsDeleteOptions) run(cmd *cobra.Command, api *client.API) error {
 	deleteSecretsParams := operations.NewDeleteSecretsParams()
 	deleteSecretsParams.SetAccessToken(&o.token)
 	deleteSecretsParams.SetSecrets(o.secrets)
 
-	api, err := client.ApiClient()
-	if err != nil {
-		return err
-	}
 	deleteSecretsResp, err := api.Operations.DeleteSecrets(deleteSecretsParams)
 	if err != nil {
 		return handleSecretsDeleteApiError(err)

--- a/cmd/secrets_list.go
+++ b/cmd/secrets_list.go
@@ -29,7 +29,7 @@ type secretsListOptions struct {
 }
 
 // newSecretsListCmd creates a command to list user secrets.
-func newSecretsListCmd() *cobra.Command {
+func newSecretsListCmd(api *client.API) *cobra.Command {
 	o := &secretsListOptions{}
 
 	cmd := &cobra.Command{
@@ -38,7 +38,7 @@ func newSecretsListCmd() *cobra.Command {
 		Long:  secretsListDesc,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return o.run(cmd)
+			return o.run(cmd, api)
 		},
 	}
 
@@ -48,14 +48,10 @@ func newSecretsListCmd() *cobra.Command {
 	return cmd
 }
 
-func (o *secretsListOptions) run(cmd *cobra.Command) error {
+func (o *secretsListOptions) run(cmd *cobra.Command, api *client.API) error {
 	listSecretsParams := operations.NewGetSecretsParams()
 	listSecretsParams.SetAccessToken(&o.token)
 
-	api, err := client.ApiClient()
-	if err != nil {
-		return err
-	}
 	listSecretsResp, err := api.Operations.GetSecrets(listSecretsParams)
 	if err != nil {
 		return err

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -10,6 +10,7 @@ package cmd
 
 import (
 	"fmt"
+	"reanahub/reana-client-go/client"
 	"reanahub/reana-client-go/client/operations"
 	"reanahub/reana-client-go/pkg/displayer"
 	"reanahub/reana-client-go/pkg/formatter"
@@ -51,7 +52,7 @@ type statusOptions struct {
 }
 
 // newStatusCmd creates a command to get status of a workflow.
-func newStatusCmd() *cobra.Command {
+func newStatusCmd(api *client.API) *cobra.Command {
 	o := &statusOptions{}
 
 	cmd := &cobra.Command{
@@ -60,7 +61,7 @@ func newStatusCmd() *cobra.Command {
 		Long:  statusDesc,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return o.run(cmd)
+			return o.run(cmd, api)
 		},
 	}
 
@@ -86,8 +87,8 @@ In case a workflow is in progress, its duration as of now will be shown.`,
 	return cmd
 }
 
-func (o *statusOptions) run(cmd *cobra.Command) error {
-	payload, err := workflows.GetStatus(o.token, o.workflow)
+func (o *statusOptions) run(cmd *cobra.Command, api *client.API) error {
+	payload, err := workflows.GetStatus(api, o.token, o.workflow)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -24,8 +24,10 @@ import (
 )
 
 func main() {
-	rootCmd := cmd.NewRootCmd()
-	err := rootCmd.Execute()
+	rootCmd, err := cmd.NewRootCmd()
+	if err == nil {
+		err = rootCmd.Execute()
+	}
 
 	if err != nil {
 		log.Debug(err)

--- a/pkg/workflows/manager.go
+++ b/pkg/workflows/manager.go
@@ -17,6 +17,7 @@ import (
 
 // UpdateStatus updates the status of the specified workflow.
 func UpdateStatus(
+	api *client.API,
 	token, workflow, status string,
 	includeWorkspace, includeAllRuns bool,
 ) error {
@@ -33,11 +34,7 @@ func UpdateStatus(
 		Workspace: includeWorkspace,
 	})
 
-	api, err := client.ApiClient()
-	if err != nil {
-		return err
-	}
-	_, err = api.Operations.SetWorkflowStatus(deleteParams)
+	_, err := api.Operations.SetWorkflowStatus(deleteParams)
 	if err != nil {
 		return err
 	}
@@ -46,15 +43,11 @@ func UpdateStatus(
 }
 
 // GetStatus returns the status information of the specified workflow.
-func GetStatus(token, workflow string) (*operations.GetWorkflowStatusOKBody, error) {
+func GetStatus(api *client.API, token, workflow string) (*operations.GetWorkflowStatusOKBody, error) {
 	getParams := operations.NewGetWorkflowStatusParams()
 	getParams.SetAccessToken(&token)
 	getParams.SetWorkflowIDOrName(workflow)
 
-	api, err := client.ApiClient()
-	if err != nil {
-		return nil, err
-	}
 	resp, err := api.Operations.GetWorkflowStatus(getParams)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
closes #76 

This PR contains my try at implementing this issue but I don't think it's worth to change they way we handle viper. The issue was opened with the idea of simplifying tests, but currently this seems to make it harder. I think the only advantage of this would be to run tests concurrently, which we currently do not have.

As you can see, this approach has the following problems:
-  If we're instantiating viper once in `root.go` then we have to either pass viper to every single command or start the api client in root as well. I initially went with the second approach, since I thought the first one would make the code a lot more verbose without much benefit.
- With the api being initiated before running any command, we have to possibly return errors to main without running the root command, which already breaks the flow of our client. To make it worse, this breaks the possibility of the user seeing the usage and version commands without setting the `REANA_SERVER_URL` env var.
- That change also breaks the way our tests are being done. Right now, we're passing the right command to `testCmdRun()`, which will then perform all the tests necessary. Since now we have dependency injection, we'd need need either create a root command instead or pass a generation function to `testCmdRun()`. Neither of them work:
  - We can't pass a root cmd because we create a circular dependency between packages
  - We have different function parameters, since some commands need viper and others don't

The viable alternative seems to be passing viper to very single command. I can do it to show how it looks like but it doesn't seem worth it to me. I'm happy to hear your thoughts on this.