### PR TITLE
cli: add generic profiler

### DIFF
--- a/cmd/profiling.go
+++ b/cmd/profiling.go
@@ -1,0 +1,87 @@
+/*
+This file is part of REANA.
+Copyright (C) 2022 CERN.
+
+REANA is free software; you can redistribute it and/or modify it
+under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"runtime/pprof"
+
+	"github.com/spf13/pflag"
+)
+
+var (
+	profileMode         string
+	profileOutputFormat string = "profile-%s.pprof"
+)
+
+func addProfilerFlags(flags *pflag.FlagSet) {
+	flags.StringVar(
+		&profileMode,
+		"profile",
+		"none",
+		"Enable profiling. One of (none|cpu|heap)",
+	)
+}
+
+func setupProfiler() error {
+	var (
+		f   *os.File
+		err error
+	)
+	switch profileMode {
+	case "none":
+		return nil
+	case "cpu":
+		profileOutput := fmt.Sprintf(profileOutputFormat, profileMode)
+		f, err = os.Create(profileOutput)
+		if err != nil {
+			return err
+		}
+		err = pprof.StartCPUProfile(f)
+		if err != nil {
+			return err
+		}
+	default:
+		// Check if the profile mode is valid.
+		if profile := pprof.Lookup(profileMode); profile == nil {
+			return fmt.Errorf("unknown profile '%s'", profileMode)
+		}
+	}
+	return nil
+}
+
+func stopProfiler() error {
+	switch profileMode {
+	case "none":
+		return nil
+	case "cpu":
+		pprof.StopCPUProfile()
+	case "heap":
+		runtime.GC()
+		fallthrough
+	default:
+		profile := pprof.Lookup(profileMode)
+		if profile == nil {
+			return nil
+		}
+		profileOutput := fmt.Sprintf(profileOutputFormat, profileMode)
+		f, err := os.Create(profileOutput)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		if err := profile.WriteTo(f, 0); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,10 +39,17 @@ func NewRootCmd() *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			return o.run(cmd)
 		},
+		PersistentPostRunE: func(*cobra.Command, []string) error {
+			if err := stopProfiler(); err != nil {
+				return err
+			}
+			return nil
+		},
 	}
 
 	cmd.SetOut(os.Stdout)
 
+	addProfilerFlags(cmd.PersistentFlags())
 	cmd.PersistentFlags().
 		StringVarP(&o.logLevel, "loglevel", "l", "WARNING", "Sets log level [DEBUG|INFO|WARNING]")
 
@@ -116,6 +123,9 @@ func NewRootCmd() *cobra.Command {
 }
 
 func (o *rootOptions) run(cmd *cobra.Command) error {
+	if err := setupProfiler(); err != nil {
+		return err
+	}
 	if err := setupLogger(o.logLevel); err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-openapi/strfmt v0.21.3
 	github.com/go-openapi/swag v0.21.1
 	github.com/go-openapi/validate v0.22.0
+	github.com/iancoleman/orderedmap v0.2.0
 	github.com/jedib0t/go-pretty/v6 v6.3.5
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
@@ -26,7 +27,6 @@ require (
 	github.com/go-openapi/loads v0.21.1 // indirect
 	github.com/go-openapi/spec v0.20.6 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/iancoleman/orderedmap v0.2.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect


### PR DESCRIPTION
closes https://github.com/reanahub/reana-client-go/issues/101

to test:
```
go run . list --profile=cpu
go tool pprof -text profile.pprof
```