### PR TITLE
cli: implement upload command

### DIFF
--- a/client/operations/get_workflow_specification_responses.go
+++ b/client/operations/get_workflow_specification_responses.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
@@ -62,20 +63,22 @@ func NewGetWorkflowSpecificationOK() *GetWorkflowSpecificationOK {
 Request succeeded. Workflow specification is returned.
 */
 type GetWorkflowSpecificationOK struct {
-	Payload interface{}
+	Payload *GetWorkflowSpecificationOKBody
 }
 
 func (o *GetWorkflowSpecificationOK) Error() string {
 	return fmt.Sprintf("[GET /api/workflows/{workflow_id_or_name}/specification][%d] getWorkflowSpecificationOK  %+v", 200, o.Payload)
 }
-func (o *GetWorkflowSpecificationOK) GetPayload() interface{} {
+func (o *GetWorkflowSpecificationOK) GetPayload() *GetWorkflowSpecificationOKBody {
 	return o.Payload
 }
 
 func (o *GetWorkflowSpecificationOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
+	o.Payload = new(GetWorkflowSpecificationOKBody)
+
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -282,6 +285,503 @@ func (o *GetWorkflowSpecificationNotFoundBody) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (o *GetWorkflowSpecificationNotFoundBody) UnmarshalBinary(b []byte) error {
 	var res GetWorkflowSpecificationNotFoundBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+/*GetWorkflowSpecificationOKBody get workflow specification o k body
+swagger:model GetWorkflowSpecificationOKBody
+*/
+type GetWorkflowSpecificationOKBody struct {
+
+	// parameters
+	Parameters interface{} `json:"parameters,omitempty"`
+
+	// specification
+	Specification *GetWorkflowSpecificationOKBodySpecification `json:"specification,omitempty"`
+}
+
+// Validate validates this get workflow specification o k body
+func (o *GetWorkflowSpecificationOKBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateSpecification(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetWorkflowSpecificationOKBody) validateSpecification(formats strfmt.Registry) error {
+	if swag.IsZero(o.Specification) { // not required
+		return nil
+	}
+
+	if o.Specification != nil {
+		if err := o.Specification.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("getWorkflowSpecificationOK" + "." + "specification")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("getWorkflowSpecificationOK" + "." + "specification")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get workflow specification o k body based on the context it is used
+func (o *GetWorkflowSpecificationOKBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.contextValidateSpecification(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetWorkflowSpecificationOKBody) contextValidateSpecification(ctx context.Context, formats strfmt.Registry) error {
+
+	if o.Specification != nil {
+		if err := o.Specification.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("getWorkflowSpecificationOK" + "." + "specification")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("getWorkflowSpecificationOK" + "." + "specification")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetWorkflowSpecificationOKBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetWorkflowSpecificationOKBody) UnmarshalBinary(b []byte) error {
+	var res GetWorkflowSpecificationOKBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+/*GetWorkflowSpecificationOKBodySpecification get workflow specification o k body specification
+swagger:model GetWorkflowSpecificationOKBodySpecification
+*/
+type GetWorkflowSpecificationOKBodySpecification struct {
+
+	// inputs
+	Inputs *GetWorkflowSpecificationOKBodySpecificationInputs `json:"inputs,omitempty"`
+
+	// outputs
+	Outputs *GetWorkflowSpecificationOKBodySpecificationOutputs `json:"outputs,omitempty"`
+
+	// version
+	Version string `json:"version,omitempty"`
+
+	// workflow
+	Workflow *GetWorkflowSpecificationOKBodySpecificationWorkflow `json:"workflow,omitempty"`
+}
+
+// Validate validates this get workflow specification o k body specification
+func (o *GetWorkflowSpecificationOKBodySpecification) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateInputs(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateOutputs(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateWorkflow(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetWorkflowSpecificationOKBodySpecification) validateInputs(formats strfmt.Registry) error {
+	if swag.IsZero(o.Inputs) { // not required
+		return nil
+	}
+
+	if o.Inputs != nil {
+		if err := o.Inputs.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("getWorkflowSpecificationOK" + "." + "specification" + "." + "inputs")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("getWorkflowSpecificationOK" + "." + "specification" + "." + "inputs")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (o *GetWorkflowSpecificationOKBodySpecification) validateOutputs(formats strfmt.Registry) error {
+	if swag.IsZero(o.Outputs) { // not required
+		return nil
+	}
+
+	if o.Outputs != nil {
+		if err := o.Outputs.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("getWorkflowSpecificationOK" + "." + "specification" + "." + "outputs")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("getWorkflowSpecificationOK" + "." + "specification" + "." + "outputs")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (o *GetWorkflowSpecificationOKBodySpecification) validateWorkflow(formats strfmt.Registry) error {
+	if swag.IsZero(o.Workflow) { // not required
+		return nil
+	}
+
+	if o.Workflow != nil {
+		if err := o.Workflow.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("getWorkflowSpecificationOK" + "." + "specification" + "." + "workflow")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("getWorkflowSpecificationOK" + "." + "specification" + "." + "workflow")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get workflow specification o k body specification based on the context it is used
+func (o *GetWorkflowSpecificationOKBodySpecification) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.contextValidateInputs(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.contextValidateOutputs(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.contextValidateWorkflow(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetWorkflowSpecificationOKBodySpecification) contextValidateInputs(ctx context.Context, formats strfmt.Registry) error {
+
+	if o.Inputs != nil {
+		if err := o.Inputs.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("getWorkflowSpecificationOK" + "." + "specification" + "." + "inputs")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("getWorkflowSpecificationOK" + "." + "specification" + "." + "inputs")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (o *GetWorkflowSpecificationOKBodySpecification) contextValidateOutputs(ctx context.Context, formats strfmt.Registry) error {
+
+	if o.Outputs != nil {
+		if err := o.Outputs.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("getWorkflowSpecificationOK" + "." + "specification" + "." + "outputs")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("getWorkflowSpecificationOK" + "." + "specification" + "." + "outputs")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (o *GetWorkflowSpecificationOKBodySpecification) contextValidateWorkflow(ctx context.Context, formats strfmt.Registry) error {
+
+	if o.Workflow != nil {
+		if err := o.Workflow.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("getWorkflowSpecificationOK" + "." + "specification" + "." + "workflow")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("getWorkflowSpecificationOK" + "." + "specification" + "." + "workflow")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetWorkflowSpecificationOKBodySpecification) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetWorkflowSpecificationOKBodySpecification) UnmarshalBinary(b []byte) error {
+	var res GetWorkflowSpecificationOKBodySpecification
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+/*GetWorkflowSpecificationOKBodySpecificationInputs get workflow specification o k body specification inputs
+swagger:model GetWorkflowSpecificationOKBodySpecificationInputs
+*/
+type GetWorkflowSpecificationOKBodySpecificationInputs struct {
+
+	// directories
+	Directories []string `json:"directories"`
+
+	// files
+	Files []string `json:"files"`
+
+	// options
+	Options interface{} `json:"options,omitempty"`
+
+	// parameters
+	Parameters interface{} `json:"parameters,omitempty"`
+}
+
+// Validate validates this get workflow specification o k body specification inputs
+func (o *GetWorkflowSpecificationOKBodySpecificationInputs) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this get workflow specification o k body specification inputs based on context it is used
+func (o *GetWorkflowSpecificationOKBodySpecificationInputs) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetWorkflowSpecificationOKBodySpecificationInputs) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetWorkflowSpecificationOKBodySpecificationInputs) UnmarshalBinary(b []byte) error {
+	var res GetWorkflowSpecificationOKBodySpecificationInputs
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+/*GetWorkflowSpecificationOKBodySpecificationOutputs get workflow specification o k body specification outputs
+swagger:model GetWorkflowSpecificationOKBodySpecificationOutputs
+*/
+type GetWorkflowSpecificationOKBodySpecificationOutputs struct {
+
+	// directories
+	Directories []string `json:"directories"`
+
+	// files
+	Files []string `json:"files"`
+}
+
+// Validate validates this get workflow specification o k body specification outputs
+func (o *GetWorkflowSpecificationOKBodySpecificationOutputs) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this get workflow specification o k body specification outputs based on context it is used
+func (o *GetWorkflowSpecificationOKBodySpecificationOutputs) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetWorkflowSpecificationOKBodySpecificationOutputs) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetWorkflowSpecificationOKBodySpecificationOutputs) UnmarshalBinary(b []byte) error {
+	var res GetWorkflowSpecificationOKBodySpecificationOutputs
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+/*GetWorkflowSpecificationOKBodySpecificationWorkflow get workflow specification o k body specification workflow
+swagger:model GetWorkflowSpecificationOKBodySpecificationWorkflow
+*/
+type GetWorkflowSpecificationOKBodySpecificationWorkflow struct {
+
+	// file
+	File string `json:"file,omitempty"`
+
+	// specification
+	Specification *GetWorkflowSpecificationOKBodySpecificationWorkflowSpecification `json:"specification,omitempty"`
+
+	// type
+	Type string `json:"type,omitempty"`
+}
+
+// Validate validates this get workflow specification o k body specification workflow
+func (o *GetWorkflowSpecificationOKBodySpecificationWorkflow) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateSpecification(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetWorkflowSpecificationOKBodySpecificationWorkflow) validateSpecification(formats strfmt.Registry) error {
+	if swag.IsZero(o.Specification) { // not required
+		return nil
+	}
+
+	if o.Specification != nil {
+		if err := o.Specification.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("getWorkflowSpecificationOK" + "." + "specification" + "." + "workflow" + "." + "specification")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("getWorkflowSpecificationOK" + "." + "specification" + "." + "workflow" + "." + "specification")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ContextValidate validate this get workflow specification o k body specification workflow based on the context it is used
+func (o *GetWorkflowSpecificationOKBodySpecificationWorkflow) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.contextValidateSpecification(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *GetWorkflowSpecificationOKBodySpecificationWorkflow) contextValidateSpecification(ctx context.Context, formats strfmt.Registry) error {
+
+	if o.Specification != nil {
+		if err := o.Specification.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("getWorkflowSpecificationOK" + "." + "specification" + "." + "workflow" + "." + "specification")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("getWorkflowSpecificationOK" + "." + "specification" + "." + "workflow" + "." + "specification")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetWorkflowSpecificationOKBodySpecificationWorkflow) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetWorkflowSpecificationOKBodySpecificationWorkflow) UnmarshalBinary(b []byte) error {
+	var res GetWorkflowSpecificationOKBodySpecificationWorkflow
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+/*GetWorkflowSpecificationOKBodySpecificationWorkflowSpecification get workflow specification o k body specification workflow specification
+swagger:model GetWorkflowSpecificationOKBodySpecificationWorkflowSpecification
+*/
+type GetWorkflowSpecificationOKBodySpecificationWorkflowSpecification struct {
+
+	// steps
+	Steps []interface{} `json:"steps"`
+}
+
+// Validate validates this get workflow specification o k body specification workflow specification
+func (o *GetWorkflowSpecificationOKBodySpecificationWorkflowSpecification) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this get workflow specification o k body specification workflow specification based on context it is used
+func (o *GetWorkflowSpecificationOKBodySpecificationWorkflowSpecification) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *GetWorkflowSpecificationOKBodySpecificationWorkflowSpecification) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *GetWorkflowSpecificationOKBodySpecificationWorkflowSpecification) UnmarshalBinary(b []byte) error {
+	var res GetWorkflowSpecificationOKBodySpecificationWorkflowSpecification
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -101,7 +101,7 @@ func NewRootCmd() *cobra.Command {
 			Message: "Workspace file management commands:",
 			Commands: []*cobra.Command{
 				// download
-				// upload
+				newUploadCmd(),
 				newDuCmd(),
 				newLsCmd(),
 				newRmCmd(),

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -1,0 +1,168 @@
+/*
+This file is part of REANA.
+Copyright (C) 2022 CERN.
+
+REANA is free software; you can redistribute it and/or modify it
+under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reanahub/reana-client-go/pkg/displayer"
+	"reanahub/reana-client-go/pkg/workflows"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
+)
+
+const uploadDesc = `
+Upload files and directories to workspace.
+
+The ` + "``upload``" + ` command allows to upload workflow input files and
+directories. The SOURCES argument can be repeated and specifies which files
+and directories are to be uploaded, see examples below. The default
+behaviour is to upload all input files and directories specified in the
+reana.yaml file.
+
+Examples:
+
+  $ reana-client upload -w myanalysis.42
+
+  $ reana-client upload -w myanalysis.42 code/mycode.py
+`
+
+type uploadOptions struct {
+	token    string
+	workflow string
+}
+
+// newUploadCmd creates a command to upload files and directories to workspace.
+func newUploadCmd() *cobra.Command {
+	o := &uploadOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "upload",
+		Short: "Upload files and directories to workspace.",
+		Long:  uploadDesc,
+		Args:  cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.run(cmd, args)
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVarP(&o.token, "access-token", "t", "", "Access token of the current user.")
+	f.StringVarP(
+		&o.workflow,
+		"workflow",
+		"w", "",
+		"Name or UUID of the workflow. Overrides value of REANA_WORKON environment variable.",
+	)
+
+	return cmd
+}
+
+// TODO: filter files based on .gitignore and .reanaignore
+
+func (o *uploadOptions) run(cmd *cobra.Command, args []string) error {
+	var inputPaths []string
+
+	if len(args) > 0 {
+		// upload files and directories specified in arguments.
+		inputPaths = args
+	} else {
+		// upload all input files and directories specified in the reana.yaml file.
+		spec, err := workflows.GetWorkflowSpecification(o.token, o.workflow)
+		if err != nil {
+			return err
+		}
+		inputFiles := spec.Specification.Inputs.Files
+		inputDirs := spec.Specification.Inputs.Directories
+		if err := o.validateInputs(inputFiles, inputDirs); err != nil {
+			return err
+		}
+		inputPaths = append(inputFiles, inputDirs...)
+	}
+
+	files, err := o.collectFiles(cmd, inputPaths)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		_, err := workflows.UploadFile(o.token, o.workflow, file)
+		if err != nil {
+			return err
+		}
+		displayer.DisplayMessage(
+			fmt.Sprintf("File %s was successfully uploaded.", file),
+			displayer.Success,
+			false,
+			cmd.OutOrStdout(),
+		)
+	}
+	return nil
+}
+
+func (o *uploadOptions) collectFiles(cmd *cobra.Command, inputPaths []string) ([]string, error) {
+	log.Debugf("Traverse all the input paths to collect files which needs to be uploaded")
+	log.Debugf("paths: %s", strings.Join(inputPaths, ", "))
+	var files []string
+	for _, dir := range inputPaths {
+		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			// Filter out directories and symlinks
+			if !info.Mode().IsRegular() {
+				if !info.IsDir() {
+					displayer.DisplayMessage(
+						fmt.Sprintf("Ignoring symlink %s", path),
+						displayer.Info,
+						false,
+						cmd.OutOrStdout(),
+					)
+				}
+				return nil
+			}
+			if !slices.Contains(files, path) {
+				files = append(files, path)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	log.Debugf("Collected files:")
+	log.Debugf("files: %s", strings.Join(files, ", "))
+	return files, nil
+}
+
+func (o *uploadOptions) validateInputs(files, dirs []string) error {
+	for _, file := range files {
+		pathInfo, err := os.Stat(file)
+		if err != nil {
+			return err
+		}
+		if pathInfo.IsDir() {
+			return fmt.Errorf("found directory in `inputs.files`: %s", file)
+		}
+	}
+	for _, dir := range dirs {
+		pathInfo, err := os.Stat(dir)
+		if err != nil {
+			return err
+		}
+		if !pathInfo.IsDir() {
+			return fmt.Errorf("found file in `inputs.directories`: %s", dir)
+		}
+	}
+	return nil
+}

--- a/cmd/upload_test.go
+++ b/cmd/upload_test.go
@@ -1,0 +1,62 @@
+/*
+This file is part of REANA.
+Copyright (C) 2022 CERN.
+
+REANA is free software; you can redistribute it and/or modify it
+under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+)
+
+var uploadServerPath = "/api/workflows/%s/workspace"
+
+func TestFileUpload(t *testing.T) {
+	testFile := t.TempDir() + "/test.txt"
+	_, err := os.Create(testFile)
+	if err != nil {
+		t.Fatalf("Error while creating test file: %s", err.Error())
+	}
+
+	tests := map[string]TestCmdParams{
+		"valid upload": {
+			serverResponses: map[string]ServerResponse{
+				fmt.Sprintf(uploadServerPath, "my_workflow"): {
+					statusCode:   http.StatusOK,
+					responseFile: "upload_success.json",
+				},
+			},
+			args: []string{"-w", "my_workflow", testFile},
+			expected: []string{
+				"test.txt was successfully uploaded.",
+			},
+		},
+		"unexisting file": {
+			args:      []string{"-w", "my_workflow", "non_existing"},
+			wantError: true,
+			expected: []string{
+				"no such file or directory",
+			},
+		},
+		"unexisting workflow": {
+			args:      []string{},
+			wantError: true,
+			expected: []string{
+				"workflow name must be provided",
+			},
+		},
+	}
+
+	for name, params := range tests {
+		t.Run(name, func(t *testing.T) {
+			params.cmd = "upload"
+			testCmdRun(t, params)
+		})
+	}
+}

--- a/pkg/workflows/manager.go
+++ b/pkg/workflows/manager.go
@@ -9,6 +9,8 @@ under the terms of the MIT License; see LICENSE file for more details.
 package workflows
 
 import (
+	"fmt"
+	"os"
 	"reanahub/reana-client-go/client"
 	"reanahub/reana-client-go/client/operations"
 	"reanahub/reana-client-go/pkg/config"
@@ -61,4 +63,53 @@ func GetStatus(token, workflow string) (*operations.GetWorkflowStatusOKBody, err
 	}
 
 	return resp.GetPayload(), nil
+}
+
+// GetWorkflowSpecification returns the specification of the specified workflow.
+func GetWorkflowSpecification(
+	token, workflow string,
+) (*operations.GetWorkflowSpecificationOKBody, error) {
+	specParams := operations.NewGetWorkflowSpecificationParams()
+	specParams.SetAccessToken(&token)
+	specParams.SetWorkflowIDOrName(workflow)
+
+	api, err := client.ApiClient()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := api.Operations.GetWorkflowSpecification(specParams)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.GetPayload(), nil
+}
+
+// UploadFile uploads a file to the specified workflow.
+func UploadFile(token, workflow, fileName string) (string, error) {
+	if err := validator.ValidateFile(fileName); err != nil {
+		return "", err
+	}
+	fileData, err := os.ReadFile(fileName)
+	if err != nil {
+		return "", fmt.Errorf(
+			"file %s could not be uploaded: %s",
+			fileName, err.Error(),
+		)
+	}
+	uploadParams := operations.NewUploadFileParams()
+	uploadParams.SetAccessToken(&token)
+	uploadParams.SetWorkflowIDOrName(workflow)
+	uploadParams.SetFileName(fileName)
+	uploadParams.SetFile(string(fileData))
+
+	api, err := client.ApiClient()
+	if err != nil {
+		return "", err
+	}
+	uploadResp, err := api.Operations.UploadFile(uploadParams)
+	if err != nil {
+		return "", err
+	}
+	return uploadResp.GetPayload().Message, nil
 }

--- a/testdata/inputs/upload_success.json
+++ b/testdata/inputs/upload_success.json
@@ -1,0 +1,3 @@
+{
+  "message": "test.txt has been successfully uploaded."
+}


### PR DESCRIPTION
closes https://github.com/reanahub/reana-client-go/issues/131

To test:
```
$ go build
$ cd ../reana-demo-helloworld 
$ reana-client create -w upload-test
$ ../reana-client-go/reana-client-go upload -w upload-test reana.yaml -l DEBUG # check https://localhost:30443 for the reana.yaml file to be present in the workspace
$ ../reana-client-go/reana-client-go upload -w upload-test -l DEBUG # check https://localhost:30443 for all the workspace input files to be present in the workspace
# modify reana.yaml to specify some input directories and test that all files are uploaded
```

Please note that https://github.com/reanahub/reana-client-go/issues/134 will be tackled in a separate PR