### PR TITLE
cli: implement share-status command

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -5,6 +5,7 @@ The list of contributors in alphabetical order:
 
 - `Audrius Mecionis <https://orcid.org/0000-0002-3759-1663>`_
 - `Bruno Rosendo <https://orcid.org/0000-0002-0923-3148>`_
+- `Daan Rosendal <https://orcid.org/0000-0002-3447-9000>`_
 - `Giuseppe Steduto <https://orcid.org/0009-0002-1258-8553>`_
 - `Marco Donadoni <https://orcid.org/0000-0003-2922-5505>`_
 - `Tibor Simko <https://orcid.org/0000-0001-7202-5803>`_

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -94,6 +94,7 @@ func NewRootCmd() *cobra.Command {
 			Message: "Workflow sharing commands:",
 			Commands: []*cobra.Command{
 				newShareAddCmd(),
+				newShareRemoveCmd(),
 			},
 		},
 		{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,6 +91,12 @@ func NewRootCmd() *cobra.Command {
 			},
 		},
 		{
+			Message: "Workflow sharing commands:",
+			Commands: []*cobra.Command{
+				newShareAddCmd(),
+			},
+		},
+		{
 			Message: "Workspace interactive commands:",
 			Commands: []*cobra.Command{
 				newOpenCmd(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -95,6 +95,7 @@ func NewRootCmd() *cobra.Command {
 			Commands: []*cobra.Command{
 				newShareAddCmd(),
 				newShareRemoveCmd(),
+				newShareStatusCmd(),
 			},
 		},
 		{

--- a/cmd/share_add.go
+++ b/cmd/share_add.go
@@ -1,0 +1,136 @@
+/*
+This file is part of REANA.
+Copyright (C) 2023 CERN.
+
+REANA is free software; you can redistribute it and/or modify it
+under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"reanahub/reana-client-go/client"
+	"reanahub/reana-client-go/client/operations"
+	"reanahub/reana-client-go/pkg/displayer"
+	"reanahub/reana-client-go/pkg/errorhandler"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+const shareAddDesc = `Share a workflow with other users (read-only).
+
+The ` + "`share-add`" + ` command allows sharing a workflow with other users. 
+The users will be able to view the workflow but not modify it.
+
+Examples: 
+
+  $ reana-client share-add -w myanalysis.42 --user bob@cern.ch
+
+  $ reana-client share-add -w myanalysis.42 --user bob@cern.ch 
+  --user cecile@cern.ch --message "Please review my analysis" 
+  --valid-until 2024-12-31
+`
+
+type shareAddOptions struct {
+	token      string
+	workflow   string
+	users      []string
+	message    string
+	validUntil string
+}
+
+// newShareAddCmd creates a command to share a workflow with other users.
+func newShareAddCmd() *cobra.Command {
+	o := &shareAddOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "share-add",
+		Short: "Share a workflow with other users (read-only).",
+		Long:  shareAddDesc,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.run(cmd)
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVarP(
+		&o.workflow,
+		"workflow",
+		"w",
+		"",
+		"Name or UUID of the workflow. Overrides value of REANA_WORKON environment variable.",
+	)
+	f.StringVarP(&o.token, "access-token", "t", "", "Access token of the current user.")
+	f.StringSliceVarP(&o.users, "user", "u", []string{}, `Users to share the workflow with.`)
+	f.StringVarP(&o.message, "message", "m", "", `Optional message that is sent to the
+	user(s) with the sharing invitation.`)
+	f.StringVarP(&o.validUntil, "valid-until", "v", "", `Optional date when access to the
+	workflow will expire for the given
+	user(s) (format: YYYY-MM-DD).`)
+	// Remove -h shorthand
+	cmd.PersistentFlags().BoolP("help", "h", false, "Help for share-add")
+
+	return cmd
+}
+
+func (o *shareAddOptions) run(cmd *cobra.Command) error {
+	shareAddParams := operations.NewShareWorkflowParams()
+	shareAddParams.SetAccessToken(&o.token)
+	shareAddParams.SetWorkflowIDOrName(o.workflow)
+	if o.message != "" {
+		shareAddParams.SetMessage(&o.message)
+	}
+
+	if o.validUntil != "" {
+		shareAddParams.SetValidUntil(&o.validUntil)
+	}
+
+	api, err := client.ApiClient()
+	if err != nil {
+		return err
+	}
+
+	shareErrors := []string{}
+	sharedUsers := []string{}
+
+	for _, user := range o.users {
+		log.Infof("Sharing workflow %s with user %s", o.workflow, user)
+
+		shareAddParams.SetUserEmailToShareWith(user)
+		_, err := api.Operations.ShareWorkflow(shareAddParams)
+
+		if err != nil {
+			err := errorhandler.HandleApiError(err)
+			shareErrors = append(
+				shareErrors,
+				fmt.Sprintf("Failed to share %s with %s: %s", o.workflow, user, err.Error()),
+			)
+		} else {
+			sharedUsers = append(sharedUsers, user)
+		}
+	}
+
+	if len(sharedUsers) > 0 {
+		displayer.DisplayMessage(
+			fmt.Sprintf(
+				"%s is now read-only shared with %s",
+				o.workflow,
+				strings.Join(sharedUsers, ", "),
+			),
+			displayer.Success,
+			false,
+			cmd.OutOrStdout(),
+		)
+	}
+	if len(shareErrors) > 0 {
+		for _, err := range shareErrors {
+			displayer.DisplayMessage(err, displayer.Error, false, cmd.OutOrStdout())
+		}
+	}
+
+	return nil
+}

--- a/cmd/share_add_test.go
+++ b/cmd/share_add_test.go
@@ -1,0 +1,72 @@
+/*
+This file is part of REANA.
+Copyright (C) 2023 CERN.
+
+REANA is free software; you can redistribute it and/or modify it under the terms
+of the MIT License; see LICENSE file for more details.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+var shareAddPathTemplate = "/api/workflows/%s/share"
+
+func TestShareAdd(t *testing.T) {
+	workflowName := "my_workflow"
+	tests := map[string]TestCmdParams{
+		"default": {
+			serverResponses: map[string]ServerResponse{
+				fmt.Sprintf(shareAddPathTemplate, workflowName): {
+					statusCode: http.StatusOK,
+				},
+			},
+			args: []string{"-w", workflowName, "--user", "bob@cern.ch"},
+			expected: []string{
+				"my_workflow is now read-only shared with bob@cern.ch",
+			},
+		},
+		"with message and valid-until": {
+			serverResponses: map[string]ServerResponse{
+				fmt.Sprintf(shareAddPathTemplate, workflowName): {
+					statusCode: http.StatusOK,
+				},
+			},
+			args: []string{
+				"-w", workflowName,
+				"--user", "bob@cern.ch",
+				"--message", "Please review my analysis",
+				"--valid-until", "2024-12-31",
+			},
+			expected: []string{
+				"my_workflow is now read-only shared with bob@cern.ch",
+			},
+		},
+		"invalid workflow": {
+			serverResponses: map[string]ServerResponse{
+				fmt.Sprintf(shareAddPathTemplate, "invalid"): {
+					statusCode:   http.StatusNotFound,
+					responseFile: "common_invalid_workflow.json",
+				},
+			},
+			args: []string{
+				"-w", "invalid",
+				"--user", "bob@cern.ch",
+			},
+			expected: []string{
+				"REANA_WORKON is set to invalid, but that workflow does not exist.",
+			},
+		},
+	}
+
+	for name, params := range tests {
+		t.Run(name, func(t *testing.T) {
+			params.cmd = "share-add"
+			testCmdRun(t, params)
+		})
+	}
+}

--- a/cmd/share_remove.go
+++ b/cmd/share_remove.go
@@ -1,0 +1,119 @@
+/*
+This file is part of REANA.
+Copyright (C) 2023 CERN.
+
+REANA is free software; you can redistribute it and/or modify it
+under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"reanahub/reana-client-go/client"
+	"reanahub/reana-client-go/client/operations"
+	"reanahub/reana-client-go/pkg/displayer"
+	"reanahub/reana-client-go/pkg/errorhandler"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+const shareRemoveDesc = `Unshare a workflow.
+
+The ` + `share-remove` + ` command allows for unsharing a workflow. The workflow
+will no longer be visible to the users with whom it was shared.
+
+Example:
+
+  $ reana-client share-remove -w myanalysis.42 --user bob@example.org
+`
+
+type shareRemoveOptions struct {
+	token    string
+	workflow string
+	users    []string
+}
+
+// newShareRemoveCmd creates a command to unshare a workflow.
+func newShareRemoveCmd() *cobra.Command {
+	o := &shareRemoveOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "share-remove",
+		Short: "Unshare a workflow.",
+		Long:  shareRemoveDesc,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.run(cmd)
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVarP(
+		&o.workflow,
+		"workflow",
+		"w",
+		"",
+		`Name or UUID of the workflow. Overrides value of 
+	REANA_WORKON environment variable.`,
+	)
+	f.StringVarP(&o.token, "access-token", "t", "", "Access token of the current user.")
+	f.StringSliceVarP(&o.users, "user", "u", []string{}, `Users to unshare the workflow with.`)
+	// Remove -h shorthand
+	cmd.PersistentFlags().BoolP("help", "h", false, "Help for share-remove")
+
+	return cmd
+}
+
+func (o *shareRemoveOptions) run(cmd *cobra.Command) error {
+	shareRemoveParams := operations.NewUnshareWorkflowParams()
+	shareRemoveParams.SetAccessToken(&o.token)
+	shareRemoveParams.SetWorkflowIDOrName(o.workflow)
+
+	api, err := client.ApiClient()
+	if err != nil {
+		return err
+	}
+
+	shareErrors := []string{}
+	sharedUsers := []string{}
+
+	for _, user := range o.users {
+		log.Infof("Unsharing workflow %s with user %s", o.workflow, user)
+
+		shareRemoveParams.SetUserEmailToUnshareWith(user)
+		_, err := api.Operations.UnshareWorkflow(shareRemoveParams)
+
+		if err != nil {
+			err := errorhandler.HandleApiError(err)
+			shareErrors = append(
+				shareErrors,
+				fmt.Sprintf("Failed to unshare %s with %s: %s", o.workflow, user, err.Error()),
+			)
+		} else {
+			sharedUsers = append(sharedUsers, user)
+		}
+	}
+
+	if len(sharedUsers) > 0 {
+		displayer.DisplayMessage(
+			fmt.Sprintf(
+				"%s is no longer shared with %s",
+				o.workflow,
+				strings.Join(sharedUsers, ", "),
+			),
+			displayer.Success,
+			false,
+			cmd.OutOrStdout(),
+		)
+	}
+	if len(shareErrors) > 0 {
+		for _, err := range shareErrors {
+			displayer.DisplayMessage(err, displayer.Error, false, cmd.OutOrStdout())
+		}
+	}
+
+	return nil
+}

--- a/cmd/share_remove_test.go
+++ b/cmd/share_remove_test.go
@@ -1,0 +1,56 @@
+/*
+This file is part of REANA.
+Copyright (C) 2023 CERN.
+
+REANA is free software; you can redistribute it and/or modify it under the terms
+of the MIT License; see LICENSE file for more details.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+var shareRemovePathTemplate = "/api/workflows/%s/unshare"
+
+func TestShareRemove(t *testing.T) {
+	workflowName := "my_workflow"
+	tests := map[string]TestCmdParams{
+		"default": {
+			serverResponses: map[string]ServerResponse{
+				fmt.Sprintf(shareRemovePathTemplate, workflowName): {
+					statusCode: http.StatusOK,
+				},
+			},
+			args: []string{"-w", workflowName, "--user", "bob@cern.ch"},
+			expected: []string{
+				"my_workflow is no longer shared with bob@cern.ch",
+			},
+		},
+		"invalid workflow": {
+			serverResponses: map[string]ServerResponse{
+				fmt.Sprintf(shareRemovePathTemplate, "invalid"): {
+					statusCode:   http.StatusNotFound,
+					responseFile: "common_invalid_workflow.json",
+				},
+			},
+			args: []string{
+				"-w", "invalid",
+				"--user", "bob@cern.ch",
+			},
+			expected: []string{
+				"REANA_WORKON is set to invalid, but that workflow does not exist.",
+			},
+		},
+	}
+
+	for name, params := range tests {
+		t.Run(name, func(t *testing.T) {
+			params.cmd = "share-remove"
+			testCmdRun(t, params)
+		})
+	}
+}

--- a/cmd/share_status.go
+++ b/cmd/share_status.go
@@ -1,0 +1,164 @@
+/*
+This file is part of REANA.
+Copyright (C) 2023 CERN.
+
+REANA is free software; you can redistribute it and/or modify it
+under the terms of the MIT License; see LICENSE file for more details.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"reanahub/reana-client-go/client"
+	"reanahub/reana-client-go/client/operations"
+	"reanahub/reana-client-go/pkg/displayer"
+	"reanahub/reana-client-go/pkg/formatter"
+
+	"github.com/go-gota/gota/dataframe"
+	"github.com/go-gota/gota/series"
+	"github.com/spf13/cobra"
+)
+
+const shareStatusFormatFlagDesc = `Format output according to column titles or column
+values. Use <columm_name>=<column_value> format.`
+
+const shareStatusDesc = `Show with whom a workflow is shared.
+
+The ` + "`share-status`" + ` command allows for checking with whom a workflow is
+shared.
+
+Example:
+
+  $ reana-client share-status -w myanalysis.42
+`
+
+type shareStatusOptions struct {
+	token         string
+	workflow      string
+	formatFilters []string
+	jsonOutput    bool
+}
+
+// newShareStatusCmd creates a command to show with whom a workflow is shared.
+func newShareStatusCmd() *cobra.Command {
+	o := &shareStatusOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "share-status",
+		Short: "Show with whom a workflow is shared.",
+		Long:  shareStatusDesc,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.run(cmd)
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVarP(
+		&o.workflow,
+		"workflow",
+		"w",
+		"",
+		`Name or UUID of the workflow. Overrides value of 
+	REANA_WORKON environment variable.`,
+	)
+	f.StringVarP(&o.token, "access-token", "t", "", "Access token of the current user.")
+	f.StringSliceVar(&o.formatFilters, "format", []string{}, shareStatusFormatFlagDesc)
+	f.BoolVar(&o.jsonOutput, "json", false, "Get output in JSON format.")
+
+	// Remove -h shorthand
+	cmd.PersistentFlags().BoolP("help", "h", false, "Help for share-status")
+
+	return cmd
+}
+
+func (o *shareStatusOptions) run(cmd *cobra.Command) error {
+	shareStatusParams := operations.NewGetWorkflowShareStatusParams()
+	shareStatusParams.SetAccessToken(&o.token)
+	shareStatusParams.SetWorkflowIDOrName(o.workflow)
+
+	api, err := client.ApiClient()
+	if err != nil {
+		return err
+	}
+	shareStatusResp, err := api.Operations.GetWorkflowShareStatus(shareStatusParams)
+	if err != nil {
+		return err
+	}
+
+	if len(shareStatusResp.Payload.SharedWith) == 0 {
+		displayer.DisplayMessage(
+			fmt.Sprintf("Workflow %s is not shared with anyone.", o.workflow),
+			displayer.Info,
+			false,
+			cmd.OutOrStdout(),
+		)
+
+		return nil
+	}
+
+	parsedFormatFilters := formatter.ParseFormatParameters(o.formatFilters, true)
+	header := []string{"user_email", "valid_until"}
+
+	err = displayShareStatusPayload(
+		cmd,
+		shareStatusResp.Payload,
+		header,
+		parsedFormatFilters,
+		o.jsonOutput,
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func displayShareStatusPayload(
+	cmd *cobra.Command,
+	payload *operations.GetWorkflowShareStatusOKBody,
+	header []string,
+	formatFilters []formatter.FormatFilter,
+	jsonOutput bool,
+) error {
+	var df dataframe.DataFrame
+	for _, col := range header {
+		colSeries := series.New([]string{}, series.String, col)
+		for _, share := range payload.SharedWith {
+			var value any
+
+			switch col {
+			case "user_email":
+				value = share.UserEmail
+			case "valid_until":
+				if share.ValidUntil != nil {
+					value = *share.ValidUntil
+				} else {
+					value = "-"
+				}
+			}
+
+			colSeries.Append(value)
+		}
+
+		df = df.CBind(dataframe.New(colSeries))
+	}
+
+	df, err := formatter.FormatDataFrame(df, formatFilters)
+	if err != nil {
+		return err
+	}
+
+	if jsonOutput {
+		err := displayer.DisplayJsonOutput(df.Maps(), cmd.OutOrStdout())
+		if err != nil {
+			return err
+		}
+	} else {
+		data := formatter.DataFrameToStringData(df)
+		displayer.DisplayTable(df.Names(), data, cmd.OutOrStdout())
+	}
+
+	return nil
+}

--- a/cmd/share_status_test.go
+++ b/cmd/share_status_test.go
@@ -1,0 +1,41 @@
+/*
+This file is part of REANA.
+Copyright (C) 2023 CERN.
+
+REANA is free software; you can redistribute it and/or modify it under the terms
+of the MIT License; see LICENSE file for more details.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+var shareStatusPathTemplate = "/api/workflows/%s/share-status"
+
+func TestShareStatus(t *testing.T) {
+	workflowName := "my_workflow"
+	tests := map[string]TestCmdParams{
+		"default": {
+			serverResponses: map[string]ServerResponse{
+				fmt.Sprintf(shareStatusPathTemplate, workflowName): {
+					statusCode: http.StatusOK,
+				},
+			},
+			args: []string{"-w", workflowName},
+			expected: []string{
+				fmt.Sprintf("Workflow %s is not shared with anyone.", workflowName),
+			},
+		},
+	}
+
+	for name, params := range tests {
+		t.Run(name, func(t *testing.T) {
+			params.cmd = "share-status"
+			testCmdRun(t, params)
+		})
+	}
+}


### PR DESCRIPTION
Adds a new command to the CLI to retrieve whom a workflow is shared with.

Closes reanahub/reana-client#686