### PR TITLE
cli: add include-last-command flag to list and status commands

### DIFF
--- a/client/operations/get_workflow_status_parameters.go
+++ b/client/operations/get_workflow_status_parameters.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewGetWorkflowStatusParams creates a new GetWorkflowStatusParams object,
@@ -66,6 +67,12 @@ type GetWorkflowStatusParams struct {
 	   The API access_token of workflow owner.
 	*/
 	AccessToken *string
+
+	/* IncludeLastCommand.
+
+	   Include additional information about the current command.
+	*/
+	IncludeLastCommand *bool
 
 	/* WorkflowIDOrName.
 
@@ -137,6 +144,17 @@ func (o *GetWorkflowStatusParams) SetAccessToken(accessToken *string) {
 	o.AccessToken = accessToken
 }
 
+// WithIncludeLastCommand adds the includeLastCommand to the get workflow status params
+func (o *GetWorkflowStatusParams) WithIncludeLastCommand(includeLastCommand *bool) *GetWorkflowStatusParams {
+	o.SetIncludeLastCommand(includeLastCommand)
+	return o
+}
+
+// SetIncludeLastCommand adds the includeLastCommand to the get workflow status params
+func (o *GetWorkflowStatusParams) SetIncludeLastCommand(includeLastCommand *bool) {
+	o.IncludeLastCommand = includeLastCommand
+}
+
 // WithWorkflowIDOrName adds the workflowIDOrName to the get workflow status params
 func (o *GetWorkflowStatusParams) WithWorkflowIDOrName(workflowIDOrName string) *GetWorkflowStatusParams {
 	o.SetWorkflowIDOrName(workflowIDOrName)
@@ -168,6 +186,23 @@ func (o *GetWorkflowStatusParams) WriteToRequest(r runtime.ClientRequest, reg st
 		if qAccessToken != "" {
 
 			if err := r.SetQueryParam("access_token", qAccessToken); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.IncludeLastCommand != nil {
+
+		// query param include_last_command
+		var qrIncludeLastCommand bool
+
+		if o.IncludeLastCommand != nil {
+			qrIncludeLastCommand = *o.IncludeLastCommand
+		}
+		qIncludeLastCommand := swag.FormatBool(qrIncludeLastCommand)
+		if qIncludeLastCommand != "" {
+
+			if err := r.SetQueryParam("include_last_command", qIncludeLastCommand); err != nil {
 				return err
 			}
 		}

--- a/client/operations/get_workflow_status_responses.go
+++ b/client/operations/get_workflow_status_responses.go
@@ -689,6 +689,9 @@ type GetWorkflowStatusOKBodyProgress struct {
 	// run started at
 	RunStartedAt *string `json:"run_started_at,omitempty"`
 
+	// run stopped at
+	RunStoppedAt *string `json:"run_stopped_at,omitempty"`
+
 	// running
 	Running *GetWorkflowStatusOKBodyProgressRunning `json:"running,omitempty"`
 

--- a/client/operations/get_workflows_parameters.go
+++ b/client/operations/get_workflows_parameters.go
@@ -68,6 +68,12 @@ type GetWorkflowsParams struct {
 	*/
 	AccessToken *string
 
+	/* IncludeLastCommand.
+
+	   Include information about the current command.
+	*/
+	IncludeLastCommand *bool
+
 	/* IncludeProgress.
 
 	   Include progress information of the workflows.
@@ -190,6 +196,17 @@ func (o *GetWorkflowsParams) WithAccessToken(accessToken *string) *GetWorkflowsP
 // SetAccessToken adds the accessToken to the get workflows params
 func (o *GetWorkflowsParams) SetAccessToken(accessToken *string) {
 	o.AccessToken = accessToken
+}
+
+// WithIncludeLastCommand adds the includeLastCommand to the get workflows params
+func (o *GetWorkflowsParams) WithIncludeLastCommand(includeLastCommand *bool) *GetWorkflowsParams {
+	o.SetIncludeLastCommand(includeLastCommand)
+	return o
+}
+
+// SetIncludeLastCommand adds the includeLastCommand to the get workflows params
+func (o *GetWorkflowsParams) SetIncludeLastCommand(includeLastCommand *bool) {
+	o.IncludeLastCommand = includeLastCommand
 }
 
 // WithIncludeProgress adds the includeProgress to the get workflows params
@@ -322,6 +339,23 @@ func (o *GetWorkflowsParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.
 		if qAccessToken != "" {
 
 			if err := r.SetQueryParam("access_token", qAccessToken); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.IncludeLastCommand != nil {
+
+		// query param include_last_command
+		var qrIncludeLastCommand bool
+
+		if o.IncludeLastCommand != nil {
+			qrIncludeLastCommand = *o.IncludeLastCommand
+		}
+		qIncludeLastCommand := swag.FormatBool(qrIncludeLastCommand)
+		if qIncludeLastCommand != "" {
+
+			if err := r.SetQueryParam("include_last_command", qIncludeLastCommand); err != nil {
 				return err
 			}
 		}

--- a/client/operations/get_workflows_responses.go
+++ b/client/operations/get_workflows_responses.go
@@ -860,6 +860,9 @@ type GetWorkflowsOKBodyItemsItems0Progress struct {
 	// run started at
 	RunStartedAt *string `json:"run_started_at,omitempty"`
 
+	// run stopped at
+	RunStoppedAt *string `json:"run_stopped_at,omitempty"`
+
 	// running
 	Running *GetWorkflowsOKBodyItemsItems0ProgressRunning `json:"running,omitempty"`
 

--- a/client/operations/launch_responses.go
+++ b/client/operations/launch_responses.go
@@ -401,22 +401,125 @@ swagger:model LaunchOKBody
 type LaunchOKBody struct {
 
 	// message
-	Message string `json:"message,omitempty"`
+	// Required: true
+	Message *string `json:"message"`
+
+	// validation warnings
+	ValidationWarnings *LaunchOKBodyValidationWarnings `json:"validation_warnings,omitempty"`
 
 	// workflow id
-	WorkflowID string `json:"workflow_id,omitempty"`
+	// Required: true
+	WorkflowID *string `json:"workflow_id"`
 
 	// workflow name
-	WorkflowName string `json:"workflow_name,omitempty"`
+	// Required: true
+	WorkflowName *string `json:"workflow_name"`
 }
 
 // Validate validates this launch o k body
 func (o *LaunchOKBody) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.validateMessage(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateValidationWarnings(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateWorkflowID(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateWorkflowName(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
 	return nil
 }
 
-// ContextValidate validates this launch o k body based on context it is used
+func (o *LaunchOKBody) validateMessage(formats strfmt.Registry) error {
+
+	if err := validate.Required("launchOK"+"."+"message", "body", o.Message); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *LaunchOKBody) validateValidationWarnings(formats strfmt.Registry) error {
+	if swag.IsZero(o.ValidationWarnings) { // not required
+		return nil
+	}
+
+	if o.ValidationWarnings != nil {
+		if err := o.ValidationWarnings.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("launchOK" + "." + "validation_warnings")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("launchOK" + "." + "validation_warnings")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (o *LaunchOKBody) validateWorkflowID(formats strfmt.Registry) error {
+
+	if err := validate.Required("launchOK"+"."+"workflow_id", "body", o.WorkflowID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *LaunchOKBody) validateWorkflowName(formats strfmt.Registry) error {
+
+	if err := validate.Required("launchOK"+"."+"workflow_name", "body", o.WorkflowName); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ContextValidate validate this launch o k body based on the context it is used
 func (o *LaunchOKBody) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	var res []error
+
+	if err := o.contextValidateValidationWarnings(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+func (o *LaunchOKBody) contextValidateValidationWarnings(ctx context.Context, formats strfmt.Registry) error {
+
+	if o.ValidationWarnings != nil {
+
+		if swag.IsZero(o.ValidationWarnings) { // not required
+			return nil
+		}
+
+		if err := o.ValidationWarnings.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("launchOK" + "." + "validation_warnings")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("launchOK" + "." + "validation_warnings")
+			}
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -431,6 +534,44 @@ func (o *LaunchOKBody) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary interface implementation
 func (o *LaunchOKBody) UnmarshalBinary(b []byte) error {
 	var res LaunchOKBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
+}
+
+/*
+LaunchOKBodyValidationWarnings Dictionary of validation warnings, if any. Each key is a property that was not correctly validated.
+swagger:model LaunchOKBodyValidationWarnings
+*/
+type LaunchOKBodyValidationWarnings struct {
+
+	// additional properties
+	AdditionalProperties []string `json:"additional_properties"`
+}
+
+// Validate validates this launch o k body validation warnings
+func (o *LaunchOKBodyValidationWarnings) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// ContextValidate validates this launch o k body validation warnings based on context it is used
+func (o *LaunchOKBodyValidationWarnings) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *LaunchOKBodyValidationWarnings) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *LaunchOKBodyValidationWarnings) UnmarshalBinary(b []byte) error {
+	var res LaunchOKBodyValidationWarnings
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -199,7 +199,7 @@ func followWorkflowExecution(
 ) error {
 	for slices.Contains([]string{"pending", "queued", "running"}, currentStatus) {
 		time.Sleep(time.Duration(config.CheckInterval) * time.Second)
-		status, err := workflows.GetStatus(token, workflow)
+		status, err := workflows.GetStatus(token, workflow, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -154,11 +154,12 @@ func TestBuildStatusHeader(t *testing.T) {
 	dummyStr := "dummy"
 
 	tests := map[string]struct {
-		verbose         bool
-		includeDuration bool
-		progress        operations.GetWorkflowStatusOKBodyProgress
-		status          string
-		expected        []string
+		verbose            bool
+		includeDuration    bool
+		includeLastCommand bool
+		progress           operations.GetWorkflowStatusOKBodyProgress
+		status             string
+		expected           []string
 	}{
 		"created status": {
 			status:   "created",
@@ -188,9 +189,18 @@ func TestBuildStatusHeader(t *testing.T) {
 			expected: []string{"name", "run_number", "created", "status", "progress"},
 		},
 		"verbose": {
-			status:   "running",
-			verbose:  true,
-			expected: []string{"name", "run_number", "created", "status", "id", "user", "duration"},
+			status:  "running",
+			verbose: true,
+			expected: []string{
+				"name",
+				"run_number",
+				"created",
+				"status",
+				"id",
+				"user",
+				"duration",
+				"last_command",
+			},
 		},
 		"verbose with command": {
 			status:   "running",
@@ -203,8 +213,8 @@ func TestBuildStatusHeader(t *testing.T) {
 				"status",
 				"id",
 				"user",
-				"command",
 				"duration",
+				"last_command",
 			},
 		},
 		"verbose with step": {
@@ -218,8 +228,8 @@ func TestBuildStatusHeader(t *testing.T) {
 				"status",
 				"id",
 				"user",
-				"command",
 				"duration",
+				"last_command",
 			},
 		},
 		"include duration": {
@@ -234,6 +244,7 @@ func TestBuildStatusHeader(t *testing.T) {
 			header := buildStatusHeader(
 				test.verbose,
 				test.includeDuration,
+				test.includeLastCommand,
 				&test.progress,
 				test.status,
 			)
@@ -277,45 +288,6 @@ func TestGetStatusProgress(t *testing.T) {
 			progress := getStatusProgress(&test.progress)
 			if progress != test.expected {
 				t.Errorf("expected %s, got %s", test.expected, progress)
-			}
-		})
-	}
-}
-
-func TestGetStatusCommand(t *testing.T) {
-	cmdStr := "cmd"
-	stepStr := "step"
-	bashCmd := "bash -c \"cd folder; ls \""
-
-	tests := map[string]struct {
-		progress operations.GetWorkflowStatusOKBodyProgress
-		expected string
-	}{
-		"no command": {
-			progress: operations.GetWorkflowStatusOKBodyProgress{CurrentStepName: &stepStr},
-			expected: stepStr,
-		},
-		"with command": {
-			progress: operations.GetWorkflowStatusOKBodyProgress{
-				CurrentCommand:  &cmdStr,
-				CurrentStepName: &stepStr,
-			},
-			expected: cmdStr,
-		},
-		"command with prefix": {
-			progress: operations.GetWorkflowStatusOKBodyProgress{
-				CurrentCommand:  &bashCmd,
-				CurrentStepName: &stepStr,
-			},
-			expected: "ls",
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			command := getStatusCommand(&test.progress)
-			if command != test.expected {
-				t.Errorf("expected %s, got %s", test.expected, command)
 			}
 		})
 	}

--- a/pkg/workflows/manager.go
+++ b/pkg/workflows/manager.go
@@ -50,9 +50,12 @@ func UpdateStatus(
 }
 
 // GetStatus returns the status information of the specified workflow.
-func GetStatus(token, workflow string) (*operations.GetWorkflowStatusOKBody, error) {
+func GetStatus(
+	token, workflow string, includeLastCommand bool,
+) (*operations.GetWorkflowStatusOKBody, error) {
 	getParams := operations.NewGetWorkflowStatusParams()
 	getParams.SetAccessToken(&token)
+	getParams.SetIncludeLastCommand(&includeLastCommand)
 	getParams.SetWorkflowIDOrName(workflow)
 
 	api, err := client.ApiClient()

--- a/pkg/workflows/utils_test.go
+++ b/pkg/workflows/utils_test.go
@@ -85,6 +85,70 @@ func TestGetDuration(t *testing.T) {
 	}
 }
 
+func TestGetLastCommand(t *testing.T) {
+	emptyString := ""
+	echoHello := "echo 'hello'"
+	echoWorld := "echo 'hello'\n\n echo 'world'"
+	step1 := "step1"
+	bashCmd := "bash -c \"cd folder; ls \""
+
+	tests := map[string]struct {
+		lastCommand *string
+		stepName    *string
+		expected    string
+	}{
+		"both nil": {
+			lastCommand: nil,
+			stepName:    nil,
+			expected:    "-",
+		},
+		"lastCommand empty": {
+			lastCommand: &emptyString,
+			stepName:    nil,
+			expected:    "-",
+		},
+		"stepName empty": {
+			lastCommand: nil,
+			stepName:    &emptyString,
+			expected:    "-",
+		},
+		"both empty": {
+			lastCommand: &emptyString,
+			stepName:    &emptyString,
+			expected:    "-",
+		},
+		"valid lastCommand": {
+			lastCommand: &echoHello,
+			stepName:    nil,
+			expected:    "echo 'hello'",
+		},
+		"valid stepName": {
+			lastCommand: nil,
+			stepName:    &step1,
+			expected:    "step1",
+		},
+		"newlines in lastCommand": {
+			lastCommand: &echoWorld,
+			stepName:    nil,
+			expected:    "echo 'hello';  echo 'world'",
+		},
+		"command with prefix": {
+			lastCommand: &bashCmd,
+			stepName:    &emptyString,
+			expected:    "ls",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := GetLastCommand(test.lastCommand, test.stepName)
+			if got != test.expected {
+				t.Errorf("Test %s: Expected %q, got %q", name, test.expected, got)
+			}
+		})
+	}
+}
+
 func TestStatusChangeMessage(t *testing.T) {
 	tests := map[string]struct {
 		workflow  string

--- a/testdata/inputs/list.json
+++ b/testdata/inputs/list.json
@@ -7,6 +7,7 @@
       "launcher_url": "https://test.test/url",
       "name": "my_workflow.23",
       "progress": {
+        "current_command": "command\n\nwith\nmultilines",
         "finished": {
           "job_ids": ["job1", "job2"],
           "total": 2


### PR DESCRIPTION
Add `--include-last-command` flag to the `list` and `status` commands
that, when set, will display info about the command currently being
executed by the workflow (or the last submitted command). In case there
is no info about the command, the step name will be displayed, if
possible.

Closes reanahub/reana-workflow-controller#486.
