### PR TITLE
fix(logs): match followed step by job_name

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -17,6 +17,7 @@ import (
 	"reanahub/reana-client-go/pkg/config"
 	"reanahub/reana-client-go/pkg/displayer"
 	"reanahub/reana-client-go/pkg/filterer"
+	"sort"
 	"strings"
 	"time"
 
@@ -272,7 +273,7 @@ func (r *logsCommandRunner) getLogsWithStatus(
 	}
 
 	if step != "" {
-		job := getFirstJob(workflowLogs.JobLogs)
+		job := findJobByStep(workflowLogs.JobLogs, step)
 		if job == nil {
 			return "", "", fmt.Errorf("step %s not found", step)
 		}
@@ -364,11 +365,24 @@ func (r *logsCommandRunner) retrieveLogs(
 	return nil
 }
 
-// getFirstJob returns the first job in the given map,
-// or nil if the map is empty.
-func getFirstJob(items map[string]jobLogItem) *jobLogItem {
-	for _, item := range items {
-		return &item
+// findJobByStep returns the job whose JobName matches step, or nil
+// if no entry matches. When several jobs share the same step name
+// (scatter and parallel steps in yadage/cwl, snakemake fan-outs,
+// retried jobs all produce many Job rows under one job_name), the
+// one with the lowest map key is returned so the choice is stable
+// across calls; ranging over a Go map directly would yield a
+// non-deterministic entry.
+func findJobByStep(items map[string]jobLogItem, step string) *jobLogItem {
+	keys := make([]string, 0, len(items))
+	for k := range items {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if items[k].JobName == step {
+			item := items[k]
+			return &item
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
When `--follow --filter step=X` is used, getLogsWithStatus() delegated to getFirstJob(), which simply returned an entry from the response map without consulting `step` at all. With Go's randomised map iteration, even the chosen "first" job varied between processes; making the choice deterministic by sorting keys (an earlier attempt) only papered over that.

Fix the helper to filter by jobLogItem.JobName matching the requested step, returning nil (-> "step X not found" error) when no entry matches. When several jobs legitimately share the same step name (some workflow engines may produce many job rows under one job_name for scatter or parallel steps), tie-break on the lowest map key so the choice is stable across calls.

This also fixes the "follow_job_with_multiple_steps" etc CI flake. The test fixture carries job1 (status finished) and job2 (status running); the test passes step=job1, and findJobByStep() now correctly returns job1 every time, so the follow loop sees status=finished and exits. The flake had been hidden by Go's per-process map seed staying stable for tiny maps within a single test run.