### PR TITLE
chore(master): backfill missing copyright years

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details

--- a/cmd/close.go
+++ b/cmd/close.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/close_test.go
+++ b/cmd/close_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2023, 2025 CERN.
+Copyright (C) 2022, 2023, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/download.go
+++ b/cmd/download.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2023, 2025 CERN.
+Copyright (C) 2022, 2023, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/download_test.go
+++ b/cmd/download_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2023, 2025 CERN.
+Copyright (C) 2022, 2023, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/du.go
+++ b/cmd/du.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2023, 2025 CERN.
+Copyright (C) 2022, 2023, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/du_test.go
+++ b/cmd/du_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2023, 2024, 2025 CERN.
+Copyright (C) 2022, 2023, 2024, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2023, 2024, 2025 CERN.
+Copyright (C) 2022, 2023, 2024, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2024, 2025 CERN.
+Copyright (C) 2022, 2024, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2024, 2025 CERN.
+Copyright (C) 2022, 2024, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2023, 2025 CERN.
+Copyright (C) 2022, 2023, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/ls_test.go
+++ b/cmd/ls_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/mv.go
+++ b/cmd/mv.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2023, 2025 CERN.
+Copyright (C) 2022, 2023, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/open_test.go
+++ b/cmd/open_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2023 CERN.
+Copyright (C) 2022, 2023, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2023, 2025 CERN.
+Copyright (C) 2023, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/prune_test.go
+++ b/cmd/prune_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2023, 2025 CERN.
+Copyright (C) 2023, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/quota_show.go
+++ b/cmd/quota_show.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/quota_show_test.go
+++ b/cmd/quota_show_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/retention_rules_list.go
+++ b/cmd/retention_rules_list.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2023, 2025 CERN.
+Copyright (C) 2022, 2023, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2024, 2025 CERN.
+Copyright (C) 2022, 2024, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/secrets_add.go
+++ b/cmd/secrets_add.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2024, 2025 CERN.
+Copyright (C) 2022, 2024, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/secrets_add_test.go
+++ b/cmd/secrets_add_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2024, 2025 CERN.
+Copyright (C) 2022, 2024, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/secrets_delete.go
+++ b/cmd/secrets_delete.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/secrets_list.go
+++ b/cmd/secrets_list.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/secrets_list_test.go
+++ b/cmd/secrets_list_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/share_add.go
+++ b/cmd/share_add.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2023, 2024, 2025 CERN.
+Copyright (C) 2023, 2024, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/share_remove.go
+++ b/cmd/share_remove.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2023, 2024, 2025 CERN.
+Copyright (C) 2023, 2024, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/share_remove_test.go
+++ b/cmd/share_remove_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2023, 2024 CERN.
+Copyright (C) 2023, 2024, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it under the terms
 of the MIT License; see LICENSE file for more details.

--- a/cmd/share_status.go
+++ b/cmd/share_status.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2023, 2024, 2025 CERN.
+Copyright (C) 2023, 2024, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/share_status_test.go
+++ b/cmd/share_status_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2023, 2025 CERN.
+Copyright (C) 2023, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it under the terms
 of the MIT License; see LICENSE file for more details.

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2024, 2025 CERN.
+Copyright (C) 2022, 2024, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/pkg/commandgroups/commandgroups.go
+++ b/pkg/commandgroups/commandgroups.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2024, 2025 CERN.
+Copyright (C) 2022, 2024, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/pkg/datautils/datautils_test.go
+++ b/pkg/datautils/datautils_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/pkg/displayer/displayer.go
+++ b/pkg/displayer/displayer.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/pkg/displayer/displayer_test.go
+++ b/pkg/displayer/displayer_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/pkg/errorhandler/errorhandler_test.go
+++ b/pkg/errorhandler/errorhandler_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/pkg/filterer/filterer.go
+++ b/pkg/filterer/filterer.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/pkg/filterer/filterer_test.go
+++ b/pkg/filterer/filterer_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2023, 2025 CERN.
+Copyright (C) 2022, 2023, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/pkg/formatter/formatter_test.go
+++ b/pkg/formatter/formatter_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2023, 2025 CERN.
+Copyright (C) 2022, 2023, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/pkg/workflows/manager.go
+++ b/pkg/workflows/manager.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2025 CERN.
+Copyright (C) 2022, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/pkg/workflows/utils.go
+++ b/pkg/workflows/utils.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2024, 2025 CERN.
+Copyright (C) 2022, 2024, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/pkg/workflows/utils_test.go
+++ b/pkg/workflows/utils_test.go
@@ -1,6 +1,6 @@
 /*
 This file is part of REANA.
-Copyright (C) 2022, 2024, 2025 CERN.
+Copyright (C) 2022, 2024, 2025, 2026 CERN.
 
 REANA is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of REANA.
-# Copyright (C) 2024, 2025 CERN.
+# Copyright (C) 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.


### PR DESCRIPTION
Update source file copyright headers and top-level LICENSE files
to include the years in which each file was modified according to
git history, without following renames.

Closes reanahub/reana#973